### PR TITLE
Add ITs for date time functions like quarter, second, second_of_minute, convert_tz, get_format

### DIFF
--- a/core/src/main/java/org/opensearch/sql/calcite/udf/datetimeUDF/ExtractFunction.java
+++ b/core/src/main/java/org/opensearch/sql/calcite/udf/datetimeUDF/ExtractFunction.java
@@ -6,14 +6,13 @@
 package org.opensearch.sql.calcite.udf.datetimeUDF;
 
 import java.time.Instant;
-import java.time.LocalDateTime;
-import java.time.ZoneOffset;
 import org.opensearch.sql.calcite.udf.UserDefinedFunction;
 import org.opensearch.sql.calcite.utils.datetime.InstantUtils;
 import org.opensearch.sql.data.model.ExprStringValue;
 import org.opensearch.sql.data.model.ExprTimestampValue;
 import org.opensearch.sql.expression.datetime.DateTimeFunctions;
 
+// TODO: Fix MICROSECOND precision, it is not correct with Calcite timestamp
 public class ExtractFunction implements UserDefinedFunction {
   @Override
   public Object eval(Object... args) {

--- a/core/src/main/java/org/opensearch/sql/calcite/udf/datetimeUDF/GetFormatFunction.java
+++ b/core/src/main/java/org/opensearch/sql/calcite/udf/datetimeUDF/GetFormatFunction.java
@@ -20,6 +20,10 @@ public class GetFormatFunction implements UserDefinedFunction {
         DateTimeFunctions.exprGetFormat(
             new ExprStringValue(argType.toString()), new ExprStringValue(argStandard.toString()));
 
+    if (fmt.isNull()) {
+      return null;
+    }
+
     return fmt.stringValue();
   }
 }

--- a/core/src/main/java/org/opensearch/sql/calcite/utils/BuiltinFunctionUtils.java
+++ b/core/src/main/java/org/opensearch/sql/calcite/utils/BuiltinFunctionUtils.java
@@ -343,7 +343,7 @@ public interface BuiltinFunctionUtils {
       case "SEC_TO_TIME":
         return TransferUserDefinedFunction(
                 secondToTimeFunction.class, "SEC_TO_TIME", ReturnTypes.TIME);
-      case "YEAR", "MINUTE", "HOUR", "HOUR_OF_DAY", "MONTH", "MONTH_OF_YEAR", "DAY_OF_MONTH", "DAYOFMONTH", "DAY", "MINUTE_OF_HOUR", "SECOND", "SECOND_OF_MINUTE":
+      case "YEAR", "QUARTER", "MINUTE", "HOUR", "HOUR_OF_DAY", "MONTH", "MONTH_OF_YEAR", "DAY_OF_MONTH", "DAYOFMONTH", "DAY", "MINUTE_OF_HOUR", "SECOND", "SECOND_OF_MINUTE":
         return SqlLibraryOperators.DATE_PART;
       case "YEARWEEK":
         return TransferUserDefinedFunction(
@@ -496,7 +496,7 @@ public interface BuiltinFunctionUtils {
         periodNameArgs.add(
             context.rexBuilder.makeFlag(argList.getFirst().getType().getSqlTypeName()));
         return periodNameArgs;
-      case "YEAR", "MINUTE", "HOUR", "DAY", "MONTH", "SECOND":
+      case "YEAR", "QUARTER", "MINUTE", "HOUR", "DAY", "MONTH", "SECOND":
         List<RexNode> extractArgs = new ArrayList<>();
         TimeUnitRange timeUnitRange = TimeUnitRange.valueOf(op);
         extractArgs.add(context.rexBuilder.makeFlag(timeUnitRange));

--- a/integ-test/src/test/java/org/opensearch/sql/calcite/standalone/CalcitePPLDateTimeBuiltinFunctionIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/calcite/standalone/CalcitePPLDateTimeBuiltinFunctionIT.java
@@ -597,4 +597,24 @@ public class CalcitePPLDateTimeBuiltinFunctionIT extends CalcitePPLIntegTestCase
             schema("timestampQuarter2", "long"));
         verifyDataRows(actual, rows(3, 2, 2));
     }
+
+    @Test
+    public void testSecond() {
+        JSONObject actual =
+            executeQuery(
+                String.format(
+                    "source=%s "
+                        + "| eval s = SECOND(TIMESTAMP('01:02:03')) "
+                        + "| eval secondForTime = SECOND(basic_time) "
+                        + "| eval secondForDate = SECOND(basic_date) "
+                        + "| eval secondForTimestamp = SECOND(strict_date_optional_time_nanos) "
+                        + "| fields s, secondForTime, secondForDate, secondForTimestamp "
+                        + "| head 1",
+                    TEST_INDEX_DATE_FORMATS));
+        verifySchema(actual, schema("s", "long"),
+            schema("secondForTime", "long"),
+            schema("secondForDate", "long"),
+            schema("secondForTimestamp", "long"));
+        verifyDataRows(actual, rows(3, 42, 0, 42));
+    }
 }

--- a/integ-test/src/test/java/org/opensearch/sql/calcite/standalone/CalcitePPLDateTimeBuiltinFunctionIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/calcite/standalone/CalcitePPLDateTimeBuiltinFunctionIT.java
@@ -617,4 +617,24 @@ public class CalcitePPLDateTimeBuiltinFunctionIT extends CalcitePPLIntegTestCase
             schema("secondForTimestamp", "long"));
         verifyDataRows(actual, rows(3, 42, 0, 42));
     }
+
+    @Test
+    public void testSecondOfMinute() {
+        JSONObject actual =
+            executeQuery(
+                String.format(
+                    "source=%s "
+                        + "| eval s = second_of_minute(TIMESTAMP('01:02:03')) "
+                        + "| eval secondForTime = second_of_minute(basic_time) "
+                        + "| eval secondForDate = second_of_minute(basic_date) "
+                        + "| eval secondForTimestamp = second_of_minute(strict_date_optional_time_nanos) "
+                        + "| fields s, secondForTime, secondForDate, secondForTimestamp "
+                        + "| head 1",
+                    TEST_INDEX_DATE_FORMATS));
+        verifySchema(actual, schema("s", "long"),
+            schema("secondForTime", "long"),
+            schema("secondForDate", "long"),
+            schema("secondForTimestamp", "long"));
+        verifyDataRows(actual, rows(3, 42, 0, 42));
+    }
 }

--- a/integ-test/src/test/java/org/opensearch/sql/calcite/standalone/CalcitePPLDateTimeBuiltinFunctionIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/calcite/standalone/CalcitePPLDateTimeBuiltinFunctionIT.java
@@ -579,4 +579,22 @@ public class CalcitePPLDateTimeBuiltinFunctionIT extends CalcitePPLIntegTestCase
         verifySchema(actual, schema("cnt", "long"));
         verifyDataRows(actual, rows(2));
     }
+
+    @Test
+    public void testQuarter() {
+        JSONObject actual =
+            executeQuery(
+                String.format(
+                    "source=%s "
+                        + "| eval `QUARTER(DATE('2020-08-26'))` = QUARTER(DATE('2020-08-26')) "
+                        + "| eval quarter2 = QUARTER(basic_date) "
+                        + "| eval timestampQuarter2 = QUARTER(basic_date_time) "
+                        + "| fields `QUARTER(DATE('2020-08-26'))`, quarter2, timestampQuarter2 "
+                        + "| head 1",
+                    TEST_INDEX_DATE_FORMATS));
+        verifySchema(actual, schema("QUARTER(DATE('2020-08-26'))", "long"),
+            schema("quarter2", "long"),
+            schema("timestampQuarter2", "long"));
+        verifyDataRows(actual, rows(3, 2, 2));
+    }
 }

--- a/integ-test/src/test/java/org/opensearch/sql/calcite/standalone/CalcitePPLDateTimeBuiltinFunctionIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/calcite/standalone/CalcitePPLDateTimeBuiltinFunctionIT.java
@@ -687,4 +687,26 @@ public class CalcitePPLDateTimeBuiltinFunctionIT extends CalcitePPLIntegTestCase
         );
         verifyDataRows(actual, rows(null, null, null));
     }
+
+    @Test
+    public void testGetFormat() {
+        JSONObject actual =
+            executeQuery(
+                String.format(
+                    "source=%s "
+                        + "| eval r1 = GET_FORMAT(DATE, 'USA') "
+                        + "| eval r2 = GET_FORMAT(TIME, 'INTERNAL') "
+                        + "| eval r3 = GET_FORMAT(TIMESTAMP, 'EUR') "
+                        + "| eval r4 = GET_FORMAT(TIMESTAMP, 'UTC') "
+                        + "| fields r1, r2, r3, r4"
+                        + "| head 1",
+                    TEST_INDEX_DATE_FORMATS));
+        System.out.println(actual.getJSONArray("datarows"));
+        verifySchema(actual, schema("r1", "string"),
+            schema("r2", "string"),
+            schema("r3", "string"),
+            schema("r4", "string")
+        );
+        verifyDataRows(actual, rows("%m.%d.%Y", "%H%i%s", "%Y-%m-%d %H.%i.%s", null));
+    }
 }

--- a/integ-test/src/test/java/org/opensearch/sql/calcite/standalone/CalcitePPLDateTimeBuiltinFunctionIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/calcite/standalone/CalcitePPLDateTimeBuiltinFunctionIT.java
@@ -701,12 +701,108 @@ public class CalcitePPLDateTimeBuiltinFunctionIT extends CalcitePPLIntegTestCase
                         + "| fields r1, r2, r3, r4"
                         + "| head 1",
                     TEST_INDEX_DATE_FORMATS));
-        System.out.println(actual.getJSONArray("datarows"));
         verifySchema(actual, schema("r1", "string"),
             schema("r2", "string"),
             schema("r3", "string"),
             schema("r4", "string")
         );
         verifyDataRows(actual, rows("%m.%d.%Y", "%H%i%s", "%Y-%m-%d %H.%i.%s", null));
+    }
+
+    // TODO: Complete IT for MICROSECOND unit once it's supported
+    @Test
+    public void testExtractWithSimpleFormats() {
+        JSONObject actual =
+            executeQuery(
+                String.format(
+                    "source=%s "
+                        + "| eval r1 = extract(YEAR FROM '1997-01-01 00:00:00') "
+                        + "| eval r2 = extract(YEAR FROM strict_date_optional_time_nanos) "
+                        + "| eval r3 = extract(year FROM basic_date) "
+                        + "| eval r4 = extract(QUARTER FROM strict_date_optional_time_nanos) "
+                        + "| eval r5 = extract(quarter FROM basic_date) "
+                        + "| eval r6 = extract(MONTH FROM strict_date_optional_time_nanos) "
+                        + "| eval r7 = extract(month FROM basic_date) "
+                        + "| eval r8 = extract(WEEK FROM strict_date_optional_time_nanos) "
+                        + "| eval r9 = extract(week FROM basic_date) "
+                        + "| eval r10 = extract(DAY FROM strict_date_optional_time_nanos) "
+                        + "| eval r11 = extract(day FROM basic_date) "
+                        + "| eval r12 = extract(HOUR FROM strict_date_optional_time_nanos) "
+                        + "| eval r13 = extract(hour FROM basic_time) "
+                        + "| eval r14 = extract(MINUTE FROM strict_date_optional_time_nanos) "
+                        + "| eval r15 = extract(minute FROM basic_time) "
+                        + "| eval r16 = extract(SECOND FROM strict_date_optional_time_nanos) "
+                        + "| eval r17 = extract(second FROM basic_time) "
+                        + "| eval r18 = extract(second FROM '09:07:42') "
+                        + "| eval r19 = extract(day FROM '1984-04-12') "
+//                        + "| eval r20 = extract(MICROSECOND FROM timestamp('1984-04-12 09:07:42.123456789')) "
+                        + "| fields r1, r2, r3, r4, r5, r6, r7, r8, r9, r10, r11, r12, r13, r14, r15, r16, r17, r18, r19 "
+                        + "| head 1",
+                    TEST_INDEX_DATE_FORMATS));
+        verifySchema(actual, schema("r1", "long"),
+            schema("r2", "long"),
+            schema("r3", "long"),
+            schema("r4", "long"),
+            schema("r5", "long"),
+            schema("r6", "long"),
+            schema("r7", "long"),
+            schema("r8", "long"),
+            schema("r9", "long"),
+            schema("r10", "long"),
+            schema("r11", "long"),
+            schema("r12", "long"),
+            schema("r13", "long"),
+            schema("r14", "long"),
+            schema("r15", "long"),
+            schema("r16", "long"),
+            schema("r17", "long"),
+            schema("r18", "long"),
+            schema("r19", "long")
+        );
+        verifyDataRows(actual, rows(1997, 1984, 1984, 2, 2, 4, 4, 15, 15, 12, 12, 9, 9, 7, 7, 42, 42, 42, 12));
+    }
+
+    // TODO: Complete IT for MICROSECOND unit once it's supported
+    @Test
+    public void testExtractWithComplexFormats() {
+        JSONObject actual =
+            executeQuery(
+                String.format(
+                    "source=%s "
+                        + "| eval r1 = extract(YEAR_MONTH FROM '1997-01-01 00:00:00') "
+                        + "| eval r2 = extract(DAY_HOUR FROM strict_date_optional_time_nanos) "
+                        + "| eval r3 = extract(DAY_HOUR FROM basic_date) "
+                        + "| eval r4 = extract(DAY_MINUTE FROM strict_date_optional_time_nanos) "
+                        + "| eval r5 = extract(DAY_MINUTE FROM basic_date) "
+                        + "| eval r6 = extract(DAY_SECOND FROM strict_date_optional_time_nanos) "
+                        + "| eval r7 = extract(DAY_SECOND FROM basic_date) "
+                        + "| eval r8 = extract(HOUR_MINUTE FROM strict_date_optional_time_nanos) "
+                        + "| eval r9 = extract(HOUR_MINUTE FROM basic_time) "
+                        + "| eval r10 = extract(HOUR_SECOND FROM strict_date_optional_time_nanos) "
+                        + "| eval r11 = extract(HOUR_SECOND FROM basic_time) "
+                        + "| eval r12 = extract(MINUTE_SECOND FROM strict_date_optional_time_nanos) "
+                        + "| eval r13 = extract(MINUTE_SECOND FROM basic_time) "
+//                        + "| eval r14 = extract(DAY_MICROSECOND FROM strict_date_optional_time_nanos) "
+//                        + "| eval r15 = extract(HOUR_MICROSECOND FROM strict_date_optional_time_nanos) "
+//                        + "| eval r16 = extract(MINUTE_MICROSECOND FROM strict_date_optional_time_nanos) "
+//                        + "| eval r17 = extract(SECOND_MICROSECOND FROM strict_date_optional_time_nanos) "
+                        + "| fields r1, r2, r3, r4, r5, r6, r7, r8, r9, r10, r11, r12, r13 "
+                        + "| head 1",
+                    TEST_INDEX_DATE_FORMATS));
+        verifySchema(actual, schema("r1", "long"),
+            schema("r2", "long"),
+            schema("r3", "long"),
+            schema("r4", "long"),
+            schema("r5", "long"),
+            schema("r6", "long"),
+            schema("r7", "long"),
+            schema("r8", "long"),
+            schema("r9", "long"),
+            schema("r10", "long"),
+            schema("r11", "long"),
+            schema("r12", "long"),
+            schema("r13", "long")
+        );
+        verifyDataRows(actual, rows(199701, 1209, 1200, 120907, 120000, 12090742, 12000000, 907, 907, 90742, 90742, 742, 742));
     }
 }


### PR DESCRIPTION
### Description
Add ITs for date time functions like quarter, second, second_of_minute, convert_tz, get_format

### Related Issues
Resolves #[Issue number to be closed when this PR is merged]
<!-- List any other related issues here -->

### Check List
- [ ] New functionality includes testing.
- [ ] New functionality has been documented.
 - [ ] New functionality has javadoc added.
 - [ ] New functionality has a user manual doc added.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [ ] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
