### PR TITLE
Fix date / time parsing with microseconds

### DIFF
--- a/core/src/main/java/org/opensearch/sql/calcite/CalciteRexNodeVisitor.java
+++ b/core/src/main/java/org/opensearch/sql/calcite/CalciteRexNodeVisitor.java
@@ -357,8 +357,11 @@ public class CalciteRexNodeVisitor extends AbstractNodeVisitor<RexNode, CalciteP
         node.getFuncArgs().stream().map(arg -> analyze(arg, context)).collect(Collectors.toList());
     SqlOperator operator = BuiltinFunctionUtils.translate(node.getFuncName());
     List<RexNode> translatedArguments =
-        BuiltinFunctionUtils.translateArgument(node.getFuncName(), arguments, context,
-                context.functionProperties.getQueryStartClock().instant().toString());
+        BuiltinFunctionUtils.translateArgument(
+            node.getFuncName(),
+            arguments,
+            context,
+            context.functionProperties.getQueryStartClock().instant().toString());
     RelDataType returnType =
         BuiltinFunctionUtils.deriveReturnType(
             node.getFuncName(), context.rexBuilder, operator, translatedArguments);

--- a/core/src/main/java/org/opensearch/sql/calcite/udf/datetimeUDF/ConvertTZFunction.java
+++ b/core/src/main/java/org/opensearch/sql/calcite/udf/datetimeUDF/ConvertTZFunction.java
@@ -5,14 +5,11 @@
 
 package org.opensearch.sql.calcite.udf.datetimeUDF;
 
-import java.sql.Timestamp;
+import static org.opensearch.sql.calcite.utils.UserDefinedFunctionUtils.formatTimestamp;
+
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
-import java.time.format.DateTimeParseException;
-import java.util.Objects;
-
-import org.apache.calcite.runtime.SqlFunctions;
 import org.apache.calcite.sql.type.SqlTypeName;
 import org.opensearch.sql.calcite.udf.UserDefinedFunction;
 import org.opensearch.sql.calcite.utils.UserDefinedFunctionUtils;
@@ -21,9 +18,6 @@ import org.opensearch.sql.data.model.ExprStringValue;
 import org.opensearch.sql.data.model.ExprTimestampValue;
 import org.opensearch.sql.data.model.ExprValue;
 import org.opensearch.sql.expression.datetime.DateTimeFunctions;
-
-import static org.opensearch.sql.calcite.utils.UserDefinedFunctionUtils.formatTimestamp;
-import static org.opensearch.sql.expression.datetime.DateTimeFunctions.exprDateTimeNoTimezone;
 
 public class ConvertTZFunction implements UserDefinedFunction {
   @Override

--- a/core/src/main/java/org/opensearch/sql/calcite/udf/datetimeUDF/DateAddSubFunction.java
+++ b/core/src/main/java/org/opensearch/sql/calcite/udf/datetimeUDF/DateAddSubFunction.java
@@ -10,13 +10,9 @@ import static org.opensearch.sql.calcite.utils.OpenSearchTypeFactory.nullableTim
 import static org.opensearch.sql.calcite.utils.UserDefinedFunctionUtils.*;
 import static org.opensearch.sql.calcite.utils.datetime.DateTimeApplyUtils.convertToTemporalAmount;
 
-import com.google.common.collect.ImmutableList;
-import java.sql.Timestamp;
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
-import java.util.Arrays;
-import java.util.Collections;
 import org.apache.calcite.avatica.util.TimeUnit;
 import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.sql.type.SqlReturnTypeInference;
@@ -37,25 +33,6 @@ public class DateAddSubFunction implements UserDefinedFunction {
       return null;
     }
 
-    //UserDefinedFunctionUtils.validateArgumentCount("DATE_ADD / DATE_SUB", 6, args.length, false);
-    /*
-    UserDefinedFunctionUtils.validateArgumentTypes(
-        Arrays.asList(args),
-        ImmutableList.of(
-            TimeUnit.class,
-            Number.class,
-            Number.class,
-            SqlTypeName.class,
-            Boolean.class,
-            SqlTypeName.class),
-        Collections.nCopies(6, true));
-
-     */
-
-    if (UserDefinedFunctionUtils.containsNull(args)) {
-      return null;
-    }
-
     TimeUnit unit = (TimeUnit) args[0];
     long interval = ((Number) args[1]).longValue();
     Object argBase = args[2];
@@ -66,10 +43,7 @@ public class DateAddSubFunction implements UserDefinedFunction {
     FunctionProperties restored = restoreFunctionProperties(args[args.length - 1]);
     ExprValue resultDatetime =
         DateTimeFunctions.exprDateApplyInterval(
-                restored,
-            new ExprTimestampValue(base),
-            convertToTemporalAmount(interval, unit),
-            isAdd);
+            restored, new ExprTimestampValue(base), convertToTemporalAmount(interval, unit), isAdd);
     Instant resultInstant = resultDatetime.timestampValue();
     if (returnSqlType == SqlTypeName.TIMESTAMP) {
       return formatTimestamp(LocalDateTime.ofInstant(resultInstant, ZoneOffset.UTC));

--- a/core/src/main/java/org/opensearch/sql/calcite/udf/datetimeUDF/DateDiffFunction.java
+++ b/core/src/main/java/org/opensearch/sql/calcite/udf/datetimeUDF/DateDiffFunction.java
@@ -5,6 +5,8 @@
 
 package org.opensearch.sql.calcite.udf.datetimeUDF;
 
+import static org.opensearch.sql.calcite.utils.UserDefinedFunctionUtils.restoreFunctionProperties;
+
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
@@ -16,8 +18,6 @@ import org.opensearch.sql.data.model.ExprTimestampValue;
 import org.opensearch.sql.data.model.ExprValue;
 import org.opensearch.sql.expression.datetime.DateTimeFunctions;
 import org.opensearch.sql.expression.function.FunctionProperties;
-
-import static org.opensearch.sql.calcite.utils.UserDefinedFunctionUtils.restoreFunctionProperties;
 
 /**
  * Calculates the difference of date parts of given values. If the first argument is time, today's
@@ -40,7 +40,7 @@ public class DateDiffFunction implements UserDefinedFunction {
     LocalDateTime localDateTime2 = LocalDateTime.ofInstant(timestamp2, ZoneOffset.UTC);
     ExprValue diffResult =
         DateTimeFunctions.exprDateDiff(
-                restored,
+            restored,
             new ExprTimestampValue(localDateTime1),
             new ExprTimestampValue(localDateTime2));
     return diffResult.longValue();

--- a/core/src/main/java/org/opensearch/sql/calcite/udf/datetimeUDF/DatetimeFunction.java
+++ b/core/src/main/java/org/opensearch/sql/calcite/udf/datetimeUDF/DatetimeFunction.java
@@ -5,17 +5,15 @@
 
 package org.opensearch.sql.calcite.udf.datetimeUDF;
 
-import java.sql.Timestamp;
+import static org.opensearch.sql.calcite.utils.UserDefinedFunctionUtils.formatTimestamp;
+
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
-import org.apache.calcite.runtime.SqlFunctions;
 import org.opensearch.sql.calcite.udf.UserDefinedFunction;
 import org.opensearch.sql.calcite.utils.UserDefinedFunctionUtils;
 import org.opensearch.sql.data.model.ExprStringValue;
 import org.opensearch.sql.data.model.ExprValue;
 import org.opensearch.sql.expression.datetime.DateTimeFunctions;
-
-import static org.opensearch.sql.calcite.utils.UserDefinedFunctionUtils.formatTimestamp;
 
 /**
  * DATETIME(timestamp)/ DATETIME(date, to_timezone) Converts the datetime to a new timezone. If not

--- a/core/src/main/java/org/opensearch/sql/calcite/udf/datetimeUDF/FromDaysFunction.java
+++ b/core/src/main/java/org/opensearch/sql/calcite/udf/datetimeUDF/FromDaysFunction.java
@@ -5,14 +5,13 @@
 
 package org.opensearch.sql.calcite.udf.datetimeUDF;
 
-import java.sql.Date;
+import static org.opensearch.sql.calcite.utils.UserDefinedFunctionUtils.formatDate;
+
 import org.opensearch.sql.calcite.udf.UserDefinedFunction;
 import org.opensearch.sql.calcite.utils.UserDefinedFunctionUtils;
 import org.opensearch.sql.data.model.ExprLongValue;
 import org.opensearch.sql.data.model.ExprValue;
 import org.opensearch.sql.expression.datetime.DateTimeFunctions;
-
-import static org.opensearch.sql.calcite.utils.UserDefinedFunctionUtils.formatDate;
 
 public class FromDaysFunction implements UserDefinedFunction {
   @Override

--- a/core/src/main/java/org/opensearch/sql/calcite/udf/datetimeUDF/FromUnixTimestampFunction.java
+++ b/core/src/main/java/org/opensearch/sql/calcite/udf/datetimeUDF/FromUnixTimestampFunction.java
@@ -5,7 +5,6 @@
 
 package org.opensearch.sql.calcite.udf.datetimeUDF;
 
-import static org.opensearch.sql.calcite.utils.OpenSearchTypeFactory.getNullableTimeUDTWithCharset;
 import static org.opensearch.sql.calcite.utils.OpenSearchTypeFactory.getNullableTimestampUDTWithCharset;
 import static org.opensearch.sql.calcite.utils.UserDefinedFunctionUtils.formatTimestamp;
 import static org.opensearch.sql.expression.datetime.DateTimeFunctions.exprFromUnixTime;
@@ -42,7 +41,8 @@ public class FromUnixTimestampFunction implements UserDefinedFunction {
 
       } else {
         double input = ((Number) value).doubleValue();
-        return formatTimestamp(LocalDateTime.ofInstant(
+        return formatTimestamp(
+            LocalDateTime.ofInstant(
                 exprFromUnixTime(new ExprDoubleValue(input)).timestampValue(), ZoneOffset.UTC));
       }
     } else if (args.length == 2) {

--- a/core/src/main/java/org/opensearch/sql/calcite/udf/datetimeUDF/MakeDateFunction.java
+++ b/core/src/main/java/org/opensearch/sql/calcite/udf/datetimeUDF/MakeDateFunction.java
@@ -10,7 +10,6 @@ import static org.opensearch.sql.expression.function.FunctionDSL.nullMissingHand
 
 import com.google.common.collect.ImmutableList;
 import java.util.Arrays;
-import org.apache.calcite.runtime.SqlFunctions;
 import org.opensearch.sql.calcite.udf.UserDefinedFunction;
 import org.opensearch.sql.calcite.utils.UserDefinedFunctionUtils;
 import org.opensearch.sql.data.model.ExprDoubleValue;

--- a/core/src/main/java/org/opensearch/sql/calcite/udf/datetimeUDF/MakeTimeFunction.java
+++ b/core/src/main/java/org/opensearch/sql/calcite/udf/datetimeUDF/MakeTimeFunction.java
@@ -5,14 +5,13 @@
 
 package org.opensearch.sql.calcite.udf.datetimeUDF;
 
-import java.sql.Time;
+import static org.opensearch.sql.calcite.utils.UserDefinedFunctionUtils.formatTime;
+
 import org.opensearch.sql.calcite.udf.UserDefinedFunction;
 import org.opensearch.sql.calcite.utils.UserDefinedFunctionUtils;
 import org.opensearch.sql.data.model.ExprDoubleValue;
 import org.opensearch.sql.data.model.ExprValue;
 import org.opensearch.sql.expression.datetime.DateTimeFunctions;
-
-import static org.opensearch.sql.calcite.utils.UserDefinedFunctionUtils.formatTime;
 
 public class MakeTimeFunction implements UserDefinedFunction {
   @Override

--- a/core/src/main/java/org/opensearch/sql/calcite/udf/datetimeUDF/MicrosecondFunction.java
+++ b/core/src/main/java/org/opensearch/sql/calcite/udf/datetimeUDF/MicrosecondFunction.java
@@ -14,12 +14,12 @@ import org.opensearch.sql.data.model.ExprTimestampValue;
 import org.opensearch.sql.expression.datetime.DateTimeFunctions;
 
 public class MicrosecondFunction implements UserDefinedFunction {
-    @Override
-    public Object eval(Object... args) {
-        if (UserDefinedFunctionUtils.containsNull(args)) {
-            return null;
-        }
-        Instant timestamp = InstantUtils.convertToInstant(args[0], (SqlTypeName) args[1], false);
-        return DateTimeFunctions.exprMicrosecond(new ExprTimestampValue(timestamp)).integerValue();
+  @Override
+  public Object eval(Object... args) {
+    if (UserDefinedFunctionUtils.containsNull(args)) {
+      return null;
     }
+    Instant timestamp = InstantUtils.convertToInstant(args[0], (SqlTypeName) args[1], false);
+    return DateTimeFunctions.exprMicrosecond(new ExprTimestampValue(timestamp)).integerValue();
+  }
 }

--- a/core/src/main/java/org/opensearch/sql/calcite/udf/datetimeUDF/MinuteOfDayFunction.java
+++ b/core/src/main/java/org/opensearch/sql/calcite/udf/datetimeUDF/MinuteOfDayFunction.java
@@ -6,7 +6,6 @@
 package org.opensearch.sql.calcite.udf.datetimeUDF;
 
 import java.time.Instant;
-
 import org.apache.calcite.sql.type.SqlTypeName;
 import org.opensearch.sql.calcite.udf.UserDefinedFunction;
 import org.opensearch.sql.calcite.utils.UserDefinedFunctionUtils;

--- a/core/src/main/java/org/opensearch/sql/calcite/udf/datetimeUDF/PeriodAddFunction.java
+++ b/core/src/main/java/org/opensearch/sql/calcite/udf/datetimeUDF/PeriodAddFunction.java
@@ -5,8 +5,6 @@
 
 package org.opensearch.sql.calcite.udf.datetimeUDF;
 
-import com.google.common.collect.ImmutableList;
-import java.util.Arrays;
 import org.opensearch.sql.calcite.udf.UserDefinedFunction;
 import org.opensearch.sql.calcite.utils.UserDefinedFunctionUtils;
 import org.opensearch.sql.data.model.ExprIntegerValue;

--- a/core/src/main/java/org/opensearch/sql/calcite/udf/datetimeUDF/PostprocessForUDTFunction.java
+++ b/core/src/main/java/org/opensearch/sql/calcite/udf/datetimeUDF/PostprocessForUDTFunction.java
@@ -1,35 +1,34 @@
 package org.opensearch.sql.calcite.udf.datetimeUDF;
 
-import org.apache.calcite.sql.type.SqlTypeName;
-import org.opensearch.sql.calcite.udf.UserDefinedFunction;
-import org.opensearch.sql.calcite.utils.datetime.InstantUtils;
+import static org.opensearch.sql.calcite.utils.UserDefinedFunctionUtils.*;
 
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
 import java.util.Objects;
-
-import static org.opensearch.sql.calcite.utils.UserDefinedFunctionUtils.*;
+import org.apache.calcite.sql.type.SqlTypeName;
+import org.opensearch.sql.calcite.udf.UserDefinedFunction;
+import org.opensearch.sql.calcite.utils.datetime.InstantUtils;
 
 public class PostprocessForUDTFunction implements UserDefinedFunction {
-    @Override
-    public Object eval(Object... args) {
-        Object candidate = args[0];
-        if (Objects.isNull(candidate)) {
-            return null;
-        }
-        SqlTypeName sqlTypeName = (SqlTypeName) args[1];
-        Instant instant = InstantUtils.convertToInstant(candidate, sqlTypeName, false);
-        LocalDateTime localDateTime = LocalDateTime.ofInstant(instant, ZoneOffset.UTC);
-        switch (sqlTypeName) {
-            case DATE:
-                return formatDate(localDateTime.toLocalDate());
-            case TIME:
-                return formatTime(localDateTime.toLocalTime());
-            case TIMESTAMP:
-                return formatTimestamp(localDateTime);
-            default:
-                throw new IllegalArgumentException("Unsupported datetime type: " + sqlTypeName);
-        }
+  @Override
+  public Object eval(Object... args) {
+    Object candidate = args[0];
+    if (Objects.isNull(candidate)) {
+      return null;
     }
+    SqlTypeName sqlTypeName = (SqlTypeName) args[1];
+    Instant instant = InstantUtils.convertToInstant(candidate, sqlTypeName, false);
+    LocalDateTime localDateTime = LocalDateTime.ofInstant(instant, ZoneOffset.UTC);
+    switch (sqlTypeName) {
+      case DATE:
+        return formatDate(localDateTime.toLocalDate());
+      case TIME:
+        return formatTime(localDateTime.toLocalTime());
+      case TIMESTAMP:
+        return formatTimestamp(localDateTime);
+      default:
+        throw new IllegalArgumentException("Unsupported datetime type: " + sqlTypeName);
+    }
+  }
 }

--- a/core/src/main/java/org/opensearch/sql/calcite/udf/datetimeUDF/PreprocessForUDTFunction.java
+++ b/core/src/main/java/org/opensearch/sql/calcite/udf/datetimeUDF/PreprocessForUDTFunction.java
@@ -5,79 +5,74 @@
 
 package org.opensearch.sql.calcite.udf.datetimeUDF;
 
-import org.apache.calcite.rel.type.RelDataType;
-import org.apache.calcite.runtime.SqlFunctions;
-import org.apache.calcite.sql.type.SqlReturnTypeInference;
-import org.apache.calcite.sql.type.SqlTypeName;
-import org.opensearch.sql.calcite.udf.UserDefinedFunction;
-import org.opensearch.sql.calcite.utils.OpenSearchTypeFactory;
-import org.opensearch.sql.calcite.utils.datetime.InstantUtils;
-import org.opensearch.sql.data.type.ExprCoreType;
-import org.opensearch.sql.data.type.ExprType;
+import static org.opensearch.sql.calcite.utils.OpenSearchTypeFactory.ExprUDT.*;
 
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
 import java.util.Objects;
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.runtime.SqlFunctions;
+import org.apache.calcite.sql.type.SqlReturnTypeInference;
+import org.apache.calcite.sql.type.SqlTypeName;
+import org.opensearch.sql.calcite.udf.UserDefinedFunction;
+import org.opensearch.sql.calcite.utils.datetime.InstantUtils;
+import org.opensearch.sql.data.type.ExprCoreType;
+import org.opensearch.sql.data.type.ExprType;
 
-import static org.opensearch.sql.calcite.utils.OpenSearchTypeFactory.ExprUDT.*;
-
-/**
- * This function is  to transfer UDT to calcite datetime types
- */
-
+/** This function is to transfer UDT to calcite datetime types */
 public class PreprocessForUDTFunction implements UserDefinedFunction {
-    @Override
-    public Object eval(Object... args) {
-        Object candidate = args[0];
-        if (Objects.isNull(candidate)) {
-            return null;
-        }
-        SqlTypeName sqlTypeName = (SqlTypeName) args[1];
-        Instant instant =  InstantUtils.fromStringExpr((String) candidate);
-        LocalDateTime localDateTime = LocalDateTime.ofInstant(instant, ZoneOffset.UTC);
-        switch (sqlTypeName) {
-            case DATE:
-                return SqlFunctions.toInt(java.sql.Date.valueOf(localDateTime.toLocalDate()));
-            case TIMESTAMP:
-                return SqlFunctions.toLong(java.sql.Timestamp.valueOf(localDateTime));
-            case TIME:
-                return SqlFunctions.toInt(java.sql.Time.valueOf(localDateTime.toLocalTime()));
-            default:
-                throw new IllegalArgumentException("Unsupported sql type: " + sqlTypeName);
-        }
+  @Override
+  public Object eval(Object... args) {
+    Object candidate = args[0];
+    if (Objects.isNull(candidate)) {
+      return null;
     }
+    SqlTypeName sqlTypeName = (SqlTypeName) args[1];
+    Instant instant = InstantUtils.fromStringExpr((String) candidate);
+    LocalDateTime localDateTime = LocalDateTime.ofInstant(instant, ZoneOffset.UTC);
+    switch (sqlTypeName) {
+      case DATE:
+        return SqlFunctions.toInt(java.sql.Date.valueOf(localDateTime.toLocalDate()));
+      case TIMESTAMP:
+        return SqlFunctions.toLong(java.sql.Timestamp.valueOf(localDateTime));
+      case TIME:
+        return SqlFunctions.toInt(java.sql.Time.valueOf(localDateTime.toLocalTime()));
+      default:
+        throw new IllegalArgumentException("Unsupported sql type: " + sqlTypeName);
+    }
+  }
 
-    public static SqlReturnTypeInference getSqlReturnTypeInference(ExprType type) {
-        return opBinding -> {
-            RelDataType relDataType;
-            switch (type) {
-                case ExprCoreType.DATE:
-                    relDataType = opBinding.getTypeFactory().createSqlType(SqlTypeName.DATE);
-                    break;
-                case ExprCoreType.TIME:
-                    relDataType = opBinding.getTypeFactory().createSqlType(SqlTypeName.TIME);
-                    break;
-                case ExprCoreType.TIMESTAMP:
-                    relDataType = opBinding.getTypeFactory().createSqlType(SqlTypeName.TIMESTAMP);
-                    break;
-                default:
-                    throw new IllegalArgumentException("Unsupported sql type: " + type);
-            }
-            return opBinding.getTypeFactory().createTypeWithNullability(relDataType, true);
-        };
-    }
+  public static SqlReturnTypeInference getSqlReturnTypeInference(ExprType type) {
+    return opBinding -> {
+      RelDataType relDataType;
+      switch (type) {
+        case ExprCoreType.DATE:
+          relDataType = opBinding.getTypeFactory().createSqlType(SqlTypeName.DATE);
+          break;
+        case ExprCoreType.TIME:
+          relDataType = opBinding.getTypeFactory().createSqlType(SqlTypeName.TIME);
+          break;
+        case ExprCoreType.TIMESTAMP:
+          relDataType = opBinding.getTypeFactory().createSqlType(SqlTypeName.TIMESTAMP);
+          break;
+        default:
+          throw new IllegalArgumentException("Unsupported sql type: " + type);
+      }
+      return opBinding.getTypeFactory().createTypeWithNullability(relDataType, true);
+    };
+  }
 
-    public static SqlTypeName getInputType(ExprType type) {
-        switch (type) {
-            case ExprCoreType.DATE:
-                return SqlTypeName.DATE;
-            case ExprCoreType.TIME:
-                return SqlTypeName.TIME;
-            case ExprCoreType.TIMESTAMP:
-                return SqlTypeName.TIMESTAMP;
-            default:
-                throw new IllegalArgumentException("Unsupported sql type: " + type);
-        }
+  public static SqlTypeName getInputType(ExprType type) {
+    switch (type) {
+      case ExprCoreType.DATE:
+        return SqlTypeName.DATE;
+      case ExprCoreType.TIME:
+        return SqlTypeName.TIME;
+      case ExprCoreType.TIMESTAMP:
+        return SqlTypeName.TIMESTAMP;
+      default:
+        throw new IllegalArgumentException("Unsupported sql type: " + type);
     }
+  }
 }

--- a/core/src/main/java/org/opensearch/sql/calcite/udf/datetimeUDF/StrToDateFunction.java
+++ b/core/src/main/java/org/opensearch/sql/calcite/udf/datetimeUDF/StrToDateFunction.java
@@ -5,20 +5,16 @@
 
 package org.opensearch.sql.calcite.udf.datetimeUDF;
 
-import java.sql.Timestamp;
+import static org.opensearch.sql.calcite.utils.UserDefinedFunctionUtils.*;
+
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
-import java.util.Arrays;
-import java.util.List;
-import org.apache.calcite.runtime.SqlFunctions;
 import org.opensearch.sql.calcite.udf.UserDefinedFunction;
 import org.opensearch.sql.calcite.utils.UserDefinedFunctionUtils;
 import org.opensearch.sql.data.model.ExprStringValue;
 import org.opensearch.sql.data.model.ExprValue;
 import org.opensearch.sql.expression.datetime.DateTimeFunctions;
 import org.opensearch.sql.expression.function.FunctionProperties;
-
-import static org.opensearch.sql.calcite.utils.UserDefinedFunctionUtils.*;
 
 /**
  * str_to_date(string, string) is used to extract a TIMESTAMP from the first argument string using
@@ -38,7 +34,7 @@ public class StrToDateFunction implements UserDefinedFunction {
     FunctionProperties restored = restoreFunctionProperties(args[args.length - 1]);
     ExprValue formatedDateExpr =
         DateTimeFunctions.exprStrToDate(
-                restored,
+            restored,
             new ExprStringValue(args[0].toString()),
             new ExprStringValue(args[1].toString()));
 
@@ -46,6 +42,7 @@ public class StrToDateFunction implements UserDefinedFunction {
       return null;
     }
 
-    return formatTimestamp(LocalDateTime.ofInstant(formatedDateExpr.timestampValue(), ZoneOffset.UTC));
+    return formatTimestamp(
+        LocalDateTime.ofInstant(formatedDateExpr.timestampValue(), ZoneOffset.UTC));
   }
 }

--- a/core/src/main/java/org/opensearch/sql/calcite/udf/datetimeUDF/TimeAddSubFunction.java
+++ b/core/src/main/java/org/opensearch/sql/calcite/udf/datetimeUDF/TimeAddSubFunction.java
@@ -5,17 +5,15 @@
 
 package org.opensearch.sql.calcite.udf.datetimeUDF;
 
-import java.sql.Time;
-import java.sql.Timestamp;
+import static org.opensearch.sql.calcite.utils.UserDefinedFunctionUtils.formatTime;
+import static org.opensearch.sql.calcite.utils.UserDefinedFunctionUtils.formatTimestamp;
+
 import java.time.*;
 import org.apache.calcite.sql.type.SqlTypeName;
 import org.opensearch.sql.calcite.udf.UserDefinedFunction;
 import org.opensearch.sql.calcite.utils.UserDefinedFunctionUtils;
 import org.opensearch.sql.calcite.utils.datetime.DateTimeApplyUtils;
 import org.opensearch.sql.calcite.utils.datetime.InstantUtils;
-
-import static org.opensearch.sql.calcite.utils.UserDefinedFunctionUtils.formatTime;
-import static org.opensearch.sql.calcite.utils.UserDefinedFunctionUtils.formatTimestamp;
 
 public class TimeAddSubFunction implements UserDefinedFunction {
   @Override

--- a/core/src/main/java/org/opensearch/sql/calcite/udf/datetimeUDF/TimeFunction.java
+++ b/core/src/main/java/org/opensearch/sql/calcite/udf/datetimeUDF/TimeFunction.java
@@ -5,20 +5,16 @@
 
 package org.opensearch.sql.calcite.udf.datetimeUDF;
 
+import static org.opensearch.sql.calcite.utils.UserDefinedFunctionUtils.formatTime;
+
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
-
 import org.apache.calcite.sql.type.SqlTypeName;
 import org.opensearch.sql.calcite.udf.UserDefinedFunction;
 import org.opensearch.sql.calcite.utils.UserDefinedFunctionUtils;
 import org.opensearch.sql.calcite.utils.datetime.InstantUtils;
-import org.opensearch.sql.data.model.ExprStringValue;
-import org.opensearch.sql.data.model.ExprTimestampValue;
 import org.opensearch.sql.data.model.ExprValue;
-import org.opensearch.sql.expression.datetime.DateTimeFunctions;
-
-import static org.opensearch.sql.calcite.utils.UserDefinedFunctionUtils.formatTime;
 
 public class TimeFunction implements UserDefinedFunction {
   @Override
@@ -33,6 +29,5 @@ public class TimeFunction implements UserDefinedFunction {
     Instant instant = InstantUtils.convertToInstant(argTime, argType, false);
     LocalDateTime localDateTime = LocalDateTime.ofInstant(instant, ZoneOffset.UTC);
     return formatTime(localDateTime.toLocalTime());
-
   }
 }

--- a/core/src/main/java/org/opensearch/sql/calcite/udf/datetimeUDF/TimestampFunction.java
+++ b/core/src/main/java/org/opensearch/sql/calcite/udf/datetimeUDF/TimestampFunction.java
@@ -5,17 +5,16 @@
 
 package org.opensearch.sql.calcite.udf.datetimeUDF;
 
+import static org.opensearch.sql.calcite.utils.UserDefinedFunctionUtils.formatTimestamp;
+
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
 import java.util.Objects;
-
 import org.apache.calcite.sql.type.SqlTypeName;
 import org.opensearch.sql.calcite.udf.UserDefinedFunction;
 import org.opensearch.sql.calcite.utils.UserDefinedFunctionUtils;
 import org.opensearch.sql.calcite.utils.datetime.InstantUtils;
-
-import static org.opensearch.sql.calcite.utils.UserDefinedFunctionUtils.formatTimestamp;
 
 /**
  * We need to write our own since we are actually implement timestamp add here

--- a/core/src/main/java/org/opensearch/sql/calcite/udf/datetimeUDF/UnixTimeStampFunction.java
+++ b/core/src/main/java/org/opensearch/sql/calcite/udf/datetimeUDF/UnixTimeStampFunction.java
@@ -12,7 +12,6 @@ import static org.opensearch.sql.utils.DateTimeFormatters.*;
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
 import java.util.Objects;
-
 import org.apache.calcite.sql.type.SqlTypeName;
 import org.opensearch.sql.calcite.udf.UserDefinedFunction;
 import org.opensearch.sql.calcite.utils.UserDefinedFunctionUtils;
@@ -42,12 +41,14 @@ public class UnixTimeStampFunction implements UserDefinedFunction {
     if (inputTypes == SqlTypeName.DATE) {
       inputValue =
           new ExprDateValue(
-              LocalDateTime.ofInstant(InstantUtils.convertToInstant(input, inputTypes, false), ZoneOffset.UTC)
+              LocalDateTime.ofInstant(
+                      InstantUtils.convertToInstant(input, inputTypes, false), ZoneOffset.UTC)
                   .toLocalDate());
     } else if (inputTypes == SqlTypeName.TIMESTAMP) {
       inputValue =
           new ExprTimestampValue(
-              LocalDateTime.ofInstant(InstantUtils.convertToInstant(input, inputTypes, false), ZoneOffset.UTC));
+              LocalDateTime.ofInstant(
+                  InstantUtils.convertToInstant(input, inputTypes, false), ZoneOffset.UTC));
     } else {
       inputValue = new ExprLongValue((long) input);
     }

--- a/core/src/main/java/org/opensearch/sql/calcite/udf/datetimeUDF/UtcTimeStampFunction.java
+++ b/core/src/main/java/org/opensearch/sql/calcite/udf/datetimeUDF/UtcTimeStampFunction.java
@@ -9,8 +9,6 @@ import static org.opensearch.sql.calcite.utils.UserDefinedFunctionUtils.formatTi
 import static org.opensearch.sql.calcite.utils.UserDefinedFunctionUtils.restoreFunctionProperties;
 import static org.opensearch.sql.expression.datetime.DateTimeFunctions.exprUtcTimeStamp;
 
-import java.time.Clock;
-import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
 import org.opensearch.sql.calcite.udf.UserDefinedFunction;
@@ -24,7 +22,7 @@ public class UtcTimeStampFunction implements UserDefinedFunction {
       return null;
     }
     FunctionProperties restored = restoreFunctionProperties(args[0]);
-    return formatTimestamp(LocalDateTime.ofInstant(
-            exprUtcTimeStamp(restored).timestampValue(), ZoneOffset.UTC));
+    return formatTimestamp(
+        LocalDateTime.ofInstant(exprUtcTimeStamp(restored).timestampValue(), ZoneOffset.UTC));
   }
 }

--- a/core/src/main/java/org/opensearch/sql/calcite/udf/datetimeUDF/WeekDayFunction.java
+++ b/core/src/main/java/org/opensearch/sql/calcite/udf/datetimeUDF/WeekDayFunction.java
@@ -26,7 +26,8 @@ public class WeekDayFunction implements UserDefinedFunction {
     FunctionProperties restored = restoreFunctionProperties(args[args.length - 1]);
     SqlTypeName sqlTypeName = (SqlTypeName) args[1];
     LocalDate candidateDate =
-        LocalDateTime.ofInstant(InstantUtils.convertToInstant(args[0], sqlTypeName, false), ZoneOffset.UTC)
+        LocalDateTime.ofInstant(
+                InstantUtils.convertToInstant(args[0], sqlTypeName, false), ZoneOffset.UTC)
             .toLocalDate();
     if (sqlTypeName == SqlTypeName.TIME) {
       return formatNow(restored.getQueryStartClock()).getDayOfWeek().getValue() - 1;

--- a/core/src/main/java/org/opensearch/sql/calcite/udf/datetimeUDF/WeekFunction.java
+++ b/core/src/main/java/org/opensearch/sql/calcite/udf/datetimeUDF/WeekFunction.java
@@ -7,10 +7,8 @@ package org.opensearch.sql.calcite.udf.datetimeUDF;
 
 import java.time.Instant;
 import java.util.Objects;
-
 import org.apache.calcite.sql.type.SqlTypeName;
 import org.opensearch.sql.calcite.udf.UserDefinedFunction;
-import org.opensearch.sql.calcite.utils.UserDefinedFunctionUtils;
 import org.opensearch.sql.calcite.utils.datetime.InstantUtils;
 import org.opensearch.sql.data.model.ExprIntegerValue;
 import org.opensearch.sql.data.model.ExprTimestampValue;
@@ -22,11 +20,11 @@ public class WeekFunction implements UserDefinedFunction {
   @Override
   public Object eval(Object... args) {
 
-      if (Objects.isNull(args[0])) {
-          return null;
-      }
+    if (Objects.isNull(args[0])) {
+      return null;
+    }
 
-     Instant i = InstantUtils.convertToInstant(args[0], (SqlTypeName) args[2], false);
+    Instant i = InstantUtils.convertToInstant(args[0], (SqlTypeName) args[2], false);
     ExprValue woyExpr =
         DateTimeFunctions.exprWeek(
             new ExprTimestampValue(i), new ExprIntegerValue((Number) args[1]));

--- a/core/src/main/java/org/opensearch/sql/calcite/udf/datetimeUDF/YearWeekFunction.java
+++ b/core/src/main/java/org/opensearch/sql/calcite/udf/datetimeUDF/YearWeekFunction.java
@@ -13,7 +13,6 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
 import java.util.Objects;
-
 import org.apache.calcite.sql.type.SqlTypeName;
 import org.opensearch.sql.calcite.udf.UserDefinedFunction;
 import org.opensearch.sql.calcite.utils.UserDefinedFunctionUtils;
@@ -49,8 +48,7 @@ public class YearWeekFunction implements UserDefinedFunction {
       mode = (int) args[1];
     }
     if (sqlTypeName == SqlTypeName.TIME) {
-      candidateDate =
-          LocalDateTime.now(restored.getQueryStartClock()).toLocalDate();
+      candidateDate = LocalDateTime.now(restored.getQueryStartClock()).toLocalDate();
     } else {
       candidateDate = LocalDateTime.ofInstant(basetime, ZoneOffset.UTC).toLocalDate();
     }

--- a/core/src/main/java/org/opensearch/sql/calcite/udf/udaf/PercentileApproxFunction.java
+++ b/core/src/main/java/org/opensearch/sql/calcite/udf/udaf/PercentileApproxFunction.java
@@ -6,18 +6,14 @@
 package org.opensearch.sql.calcite.udf.udaf;
 
 import com.tdunning.math.stats.AVLTreeDigest;
-
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
-
 import org.apache.calcite.sql.type.SqlTypeName;
 import org.opensearch.sql.calcite.udf.UserDefinedAggFunction;
 
-/**
- * We write by ourselves since it's an approximate algorithm
- */
+/** We write by ourselves since it's an approximate algorithm */
 public class PercentileApproxFunction
     implements UserDefinedAggFunction<PercentileApproxFunction.PencentileApproAccumulator> {
   SqlTypeName returnType;
@@ -42,8 +38,8 @@ public class PercentileApproxFunction
     }
     percentile = ((Number) allValues.get(1)).intValue() / 100.0;
     returnType = (SqlTypeName) allValues.get(allValues.size() - 1);
-    if (allValues.size() > 3) { //have compression
-        compression = ((Number) allValues.get(allValues.size() - 2)).doubleValue();
+    if (allValues.size() > 3) { // have compression
+      compression = ((Number) allValues.get(allValues.size() - 2)).doubleValue();
     }
 
     acc.evaluate(((Number) targetValue).doubleValue());
@@ -75,7 +71,7 @@ public class PercentileApproxFunction
   public static class PencentileApproAccumulator implements Accumulator {
     private List<Number> candidate;
 
-    public int size(){
+    public int size() {
       return candidate.size();
     }
 
@@ -87,13 +83,12 @@ public class PercentileApproxFunction
       candidate.add(value);
     }
 
-
     @Override
     public Object value(Object... argList) {
       double percent = (double) argList[1];
       double compression = (double) argList[0];
       AVLTreeDigest tree = new AVLTreeDigest(compression);
-      for (Number num: candidate) {
+      for (Number num : candidate) {
         tree.add(num.doubleValue());
       }
       return tree.quantile(percent);

--- a/core/src/main/java/org/opensearch/sql/calcite/udf/udaf/TakeAggFunction.java
+++ b/core/src/main/java/org/opensearch/sql/calcite/udf/udaf/TakeAggFunction.java
@@ -7,8 +7,6 @@ package org.opensearch.sql.calcite.udf.udaf;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Objects;
-
 import org.opensearch.sql.calcite.udf.UserDefinedAggFunction;
 
 public class TakeAggFunction implements UserDefinedAggFunction<TakeAggFunction.TakeAccumulator> {

--- a/core/src/main/java/org/opensearch/sql/calcite/utils/AggregateUtils.java
+++ b/core/src/main/java/org/opensearch/sql/calcite/utils/AggregateUtils.java
@@ -13,7 +13,6 @@ import static org.opensearch.sql.calcite.utils.UserDefinedFunctionUtils.Transfer
 import static org.opensearch.sql.calcite.utils.UserDefinedFunctionUtils.getReturnTypeInference;
 
 import com.google.common.collect.ImmutableList;
-
 import java.util.ArrayList;
 import java.util.List;
 import org.apache.calcite.rel.RelCollations;
@@ -21,7 +20,6 @@ import org.apache.calcite.rel.core.AggregateCall;
 import org.apache.calcite.rex.RexInputRef;
 import org.apache.calcite.rex.RexNode;
 import org.apache.calcite.sql.SqlAggFunction;
-import org.apache.calcite.sql.type.ReturnTypes;
 import org.apache.calcite.tools.RelBuilder;
 import org.opensearch.sql.ast.expression.AggregateFunction;
 import org.opensearch.sql.calcite.CalcitePlanContext;
@@ -80,9 +78,9 @@ public interface AggregateUtils {
         return TransferUserDefinedAggFunction(
             PercentileApproxFunction.class,
             "percentile_approx",
-                getReturnTypeInference(0),
+            getReturnTypeInference(0),
             List.of(field),
-                newArgList,
+            newArgList,
             context.relBuilder);
     }
     throw new IllegalStateException("Not Supported value: " + agg.getFuncName());

--- a/core/src/main/java/org/opensearch/sql/calcite/utils/BuiltinFunctionUtils.java
+++ b/core/src/main/java/org/opensearch/sql/calcite/utils/BuiltinFunctionUtils.java
@@ -86,9 +86,9 @@ import org.opensearch.sql.calcite.udf.mathUDF.ConvFunction;
 import org.opensearch.sql.calcite.udf.mathUDF.EulerFunction;
 import org.opensearch.sql.calcite.udf.mathUDF.ModFunction;
 import org.opensearch.sql.calcite.udf.mathUDF.SqrtFunction;
-import org.opensearch.sql.calcite.utils.datetime.DateTimeParser;
 import org.opensearch.sql.calcite.udf.textUDF.LocateFunction;
 import org.opensearch.sql.calcite.udf.textUDF.ReplaceFunction;
+import org.opensearch.sql.calcite.utils.datetime.DateTimeParser;
 
 public interface BuiltinFunctionUtils {
 
@@ -161,9 +161,7 @@ public interface BuiltinFunctionUtils {
         return TransferUserDefinedFunction(ReplaceFunction.class, "REPLACE", ReturnTypes.CHAR);
       case "LOCATE":
         return TransferUserDefinedFunction(
-            LocateFunction.class,
-            "LOCATE",
-                createNullableReturnType(SqlTypeName.INTEGER));
+            LocateFunction.class, "LOCATE", createNullableReturnType(SqlTypeName.INTEGER));
       case "UPPER":
         return SqlStdOperatorTable.UPPER;
         // Built-in Math Functions
@@ -233,33 +231,22 @@ public interface BuiltinFunctionUtils {
         // Built-in Date Functions
       case "CURRENT_TIMESTAMP", "NOW", "LOCALTIMESTAMP", "LOCALTIME":
         return TransferUserDefinedFunction(
-                PostprocessForUDTFunction.class, "POSTPROCESS", timestampInference
-        );
+            PostprocessForUDTFunction.class, "POSTPROCESS", timestampInference);
       case "CURTIME", "CURRENT_TIME":
         return TransferUserDefinedFunction(
-                PostprocessForUDTFunction.class, "POSTPROCESS", timeInference
-        );
+            PostprocessForUDTFunction.class, "POSTPROCESS", timeInference);
       case "CURRENT_DATE", "CURDATE":
         return TransferUserDefinedFunction(
-                PostprocessForUDTFunction.class, "POSTPROCESS", dateInference
-        );
+            PostprocessForUDTFunction.class, "POSTPROCESS", dateInference);
       case "DATE":
         return TransferUserDefinedFunction(
-          PostprocessForUDTFunction.class, "POSTPROCESS", dateInference
-        );
-        //return SqlLibraryOperators.DATE;
-      case "DATE_ADD":
+            PostprocessForUDTFunction.class, "POSTPROCESS", dateInference);
+        // return SqlLibraryOperators.DATE;
+      case "DATE_ADD", "DATE_SUB":
+        return TransferUserDefinedFunction(DateAddSubFunction.class, capitalOP, timestampInference);
+      case "ADDDATE", "SUBDATE":
         return TransferUserDefinedFunction(
-            DateAddSubFunction.class, "DATE_ADD", timestampInference);
-      case "ADDDATE":
-        return TransferUserDefinedFunction(
-            DateAddSubFunction.class, "ADDDATE", DateAddSubFunction.getReturnTypeForAddOrSubDate());
-      case "SUBDATE":
-        return TransferUserDefinedFunction(
-            DateAddSubFunction.class, "SUBDATE", DateAddSubFunction.getReturnTypeForAddOrSubDate());
-      case "DATE_SUB":
-        return TransferUserDefinedFunction(
-            DateAddSubFunction.class, "DATE_SUB", timestampInference);
+            DateAddSubFunction.class, capitalOP, DateAddSubFunction.getReturnTypeForAddOrSubDate());
       case "ADDTIME", "SUBTIME":
         return TransferUserDefinedFunction(
             TimeAddSubFunction.class,
@@ -277,8 +264,7 @@ public interface BuiltinFunctionUtils {
         return TransferUserDefinedFunction(
             ConvertTZFunction.class, "CONVERT_TZ", timestampInference);
       case "DATETIME":
-        return TransferUserDefinedFunction(
-            DatetimeFunction.class, "DATETIME", timestampInference);
+        return TransferUserDefinedFunction(DatetimeFunction.class, "DATETIME", timestampInference);
 
       case "FROM_DAYS":
         return TransferUserDefinedFunction(FromDaysFunction.class, "FROM_DAYS", dateInference);
@@ -293,7 +279,8 @@ public interface BuiltinFunctionUtils {
       case "MAKEDATE":
         return TransferUserDefinedFunction(MakeDateFunction.class, "MAKEDATE", dateInference);
       case "MINUTE_OF_DAY":
-        return TransferUserDefinedFunction(MinuteOfDayFunction.class, "MINUTE_OF_DAY", ReturnTypes.INTEGER);
+        return TransferUserDefinedFunction(
+            MinuteOfDayFunction.class, "MINUTE_OF_DAY", ReturnTypes.INTEGER);
       case "PERIOD_ADD":
         return TransferUserDefinedFunction(
             PeriodAddFunction.class, "PERIOD_ADD", ReturnTypes.INTEGER);
@@ -383,7 +370,7 @@ public interface BuiltinFunctionUtils {
         return SqlLibraryOperators.DATE_PART;
       case "MICROSECOND":
         return TransferUserDefinedFunction(
-                MicrosecondFunction.class, "MICROSECOND", ReturnTypes.INTEGER);
+            MicrosecondFunction.class, "MICROSECOND", ReturnTypes.INTEGER);
       case "YEARWEEK":
         return TransferUserDefinedFunction(YearWeekFunction.class, "YEARWEEK", ReturnTypes.INTEGER);
       case "FROM_UNIXTIME":
@@ -490,9 +477,7 @@ public interface BuiltinFunctionUtils {
         } else {
           DateArgs.add(wrapperByPreprocess(timestampExpr, context.rexBuilder));
         }
-        RexNode wrappedCall = context.rexBuilder.makeCall(
-                SqlLibraryOperators.DATE, DateArgs
-        );
+        RexNode wrappedCall = context.rexBuilder.makeCall(SqlLibraryOperators.DATE, DateArgs);
         return List.of(wrappedCall, context.rexBuilder.makeFlag(SqlTypeName.DATE));
       case "LAST_DAY":
         List<RexNode> LastDateArgs = new ArrayList<>();
@@ -510,13 +495,16 @@ public interface BuiltinFunctionUtils {
         }
         return LastDateArgs;
       case "CURRENT_TIMESTAMP", "NOW", "LOCALTIMESTAMP", "LOCALTIME":
-        RexNode currentTimestampCall = context.rexBuilder.makeCall(SqlStdOperatorTable.CURRENT_TIMESTAMP, List.of());
+        RexNode currentTimestampCall =
+            context.rexBuilder.makeCall(SqlStdOperatorTable.CURRENT_TIMESTAMP, List.of());
         return List.of(currentTimestampCall, context.rexBuilder.makeFlag(SqlTypeName.TIMESTAMP));
       case "CURTIME", "CURRENT_TIME":
-        RexNode currentTimeCall = context.rexBuilder.makeCall(SqlStdOperatorTable.CURRENT_TIME, List.of());
+        RexNode currentTimeCall =
+            context.rexBuilder.makeCall(SqlStdOperatorTable.CURRENT_TIME, List.of());
         return List.of(currentTimeCall, context.rexBuilder.makeFlag(SqlTypeName.TIME));
       case "CURRENT_DATE", "CURDATE":
-        RexNode currentDateCall = context.rexBuilder.makeCall(SqlStdOperatorTable.CURRENT_DATE, List.of());
+        RexNode currentDateCall =
+            context.rexBuilder.makeCall(SqlStdOperatorTable.CURRENT_DATE, List.of());
         return List.of(currentDateCall, context.rexBuilder.makeFlag(SqlTypeName.DATE));
       case "TIMESTAMP",
           "TIMEDIFF",
@@ -534,9 +522,9 @@ public interface BuiltinFunctionUtils {
       case "YEARWEEK", "WEEKDAY":
         List<RexNode> weekdayArgs = new ArrayList<>(argList);
         weekdayArgs.addAll(
-                argList.stream()
-                        .map(p -> context.rexBuilder.makeFlag(p.getType().getSqlTypeName()))
-                        .collect(Collectors.toList()));
+            argList.stream()
+                .map(p -> context.rexBuilder.makeFlag(p.getType().getSqlTypeName()))
+                .collect(Collectors.toList()));
         weekdayArgs.add(context.rexBuilder.makeLiteral(currentTimestampStr));
         return weekdayArgs;
       case "TIMESTAMPADD":
@@ -647,7 +635,9 @@ public interface BuiltinFunctionUtils {
         subTimeArgs.add(context.rexBuilder.makeLiteral(false));
         return subTimeArgs;
       case "TIME":
-        return ImmutableList.of(argList.getFirst(), context.rexBuilder.makeFlag(argList.getFirst().getType().getSqlTypeName()));
+        return ImmutableList.of(
+            argList.getFirst(),
+            context.rexBuilder.makeFlag(argList.getFirst().getType().getSqlTypeName()));
       case "DATE_FORMAT", "FORMAT_TIMESTAMP":
         RexNode dateExpr = argList.get(0);
         RexNode dateFormatPatternExpr = argList.get(1);
@@ -673,13 +663,19 @@ public interface BuiltinFunctionUtils {
             context.rexBuilder.makeIntervalLiteral(
                 new SqlIntervalQualifier(TimeUnit.DOW, null, SqlParserPos.ZERO));
         return List.of(
-            dowUnit, wrapperByPreprocess(convertToDateLiteralIfString(context.rexBuilder, argList.getFirst()), context.rexBuilder));
+            dowUnit,
+            wrapperByPreprocess(
+                convertToDateLiteralIfString(context.rexBuilder, argList.getFirst()),
+                context.rexBuilder));
       case "DAY_OF_YEAR", "DAYOFYEAR":
         RexNode domUnit =
             context.rexBuilder.makeIntervalLiteral(
                 new SqlIntervalQualifier(TimeUnit.DOY, null, SqlParserPos.ZERO));
         return List.of(
-            domUnit, wrapperByPreprocess(convertToDateLiteralIfString(context.rexBuilder, argList.getFirst()), context.rexBuilder));
+            domUnit,
+            wrapperByPreprocess(
+                convertToDateLiteralIfString(context.rexBuilder, argList.getFirst()),
+                context.rexBuilder));
       case "WEEK", "WEEK_OF_YEAR":
         RexNode woyMode;
         if (argList.size() >= 2) {
@@ -715,7 +711,8 @@ public interface BuiltinFunctionUtils {
               makeConversionCall(
                   "DATE_FORMAT",
                   ImmutableList.of(argTimestamp, context.rexBuilder.makeLiteral("%Y-%m-%d %T")),
-                  context, currentTimestampStr);
+                  context,
+                  currentTimestampStr);
         }
         return Stream.concat(Stream.of(argTimestamp), argList.stream().skip(1)).toList();
       case "UTC_TIMESTAMP", "UTC_TIME", "UTC_DATE":
@@ -726,9 +723,13 @@ public interface BuiltinFunctionUtils {
   }
 
   private static RexNode makeConversionCall(
-      String funcName, List<RexNode> arguments, CalcitePlanContext context, String currentTimestampStr) {
+      String funcName,
+      List<RexNode> arguments,
+      CalcitePlanContext context,
+      String currentTimestampStr) {
     SqlOperator operator = translate(funcName);
-    List<RexNode> translatedArguments = translateArgument(funcName, arguments, context, currentTimestampStr);
+    List<RexNode> translatedArguments =
+        translateArgument(funcName, arguments, context, currentTimestampStr);
     RelDataType returnType =
         deriveReturnType(funcName, context.rexBuilder, operator, translatedArguments);
     return context.rexBuilder.makeCall(returnType, operator, translatedArguments);
@@ -741,7 +742,8 @@ public interface BuiltinFunctionUtils {
             // This effectively invalidates the operand type check, which leads to unnecessary
             // incompatible parameter type errors
           case "DATEDIFF" -> rexBuilder.getTypeFactory().createSqlType(SqlTypeName.BIGINT);
-          //case "TIMESTAMPADD" -> rexBuilder.getTypeFactory().createSqlType(SqlTypeName.TIMESTAMP);
+            // case "TIMESTAMPADD" ->
+            // rexBuilder.getTypeFactory().createSqlType(SqlTypeName.TIMESTAMP);
           case "TIMESTAMPDIFF" -> rexBuilder.getTypeFactory().createSqlType(SqlTypeName.BIGINT);
           case "YEAR",
               "MINUTE",
@@ -811,7 +813,10 @@ public interface BuiltinFunctionUtils {
   }
 
   private static List<RexNode> transformAddOrSubDateArgs(
-      List<RexNode> argList, ExtendedRexBuilder rexBuilder, Boolean isAdd, String currentTimestampStr) {
+      List<RexNode> argList,
+      ExtendedRexBuilder rexBuilder,
+      Boolean isAdd,
+      String currentTimestampStr) {
     List<RexNode> addOrSubDateArgs = new ArrayList<>();
     addOrSubDateArgs.add(argList.getFirst());
     SqlTypeName addType = argList.get(1).getType().getSqlTypeName();

--- a/core/src/main/java/org/opensearch/sql/calcite/utils/OpenSearchTypeFactory.java
+++ b/core/src/main/java/org/opensearch/sql/calcite/utils/OpenSearchTypeFactory.java
@@ -5,7 +5,6 @@
 
 package org.opensearch.sql.calcite.utils;
 
-import static java.nio.charset.StandardCharsets.ISO_8859_1;
 import static org.opensearch.sql.data.type.ExprCoreType.ARRAY;
 import static org.opensearch.sql.data.type.ExprCoreType.BOOLEAN;
 import static org.opensearch.sql.data.type.ExprCoreType.BYTE;
@@ -56,43 +55,47 @@ public class OpenSearchTypeFactory extends JavaTypeFactoryImpl {
   public static final OpenSearchTypeFactory TYPE_FACTORY =
       new OpenSearchTypeFactory(OpenSearchTypeSystem.INSTANCE);
 
-  public static SqlReturnTypeInference timestampInference = opBinding -> {
-    //return TYPE_FACTORY.createUDT(ExprUDT.EXPR_TIMESTAMP, true);
-    Charset charset = TYPE_FACTORY.getDefaultCharset();
-    SqlCollation collation = SqlCollation.IMPLICIT;
-    RelDataType type =  TYPE_FACTORY.createUDT(ExprUDT.EXPR_TIMESTAMP, true);
-    if (type instanceof ExprBasicSqlUDT udt) {
-      return udt.createWithCharsetAndCollation(charset, collation);
-    }
-    return type;
-  };
+  public static SqlReturnTypeInference timestampInference =
+      opBinding -> {
+        // return TYPE_FACTORY.createUDT(ExprUDT.EXPR_TIMESTAMP, true);
+        Charset charset = TYPE_FACTORY.getDefaultCharset();
+        SqlCollation collation = SqlCollation.IMPLICIT;
+        RelDataType type = TYPE_FACTORY.createUDT(ExprUDT.EXPR_TIMESTAMP, true);
+        if (type instanceof ExprBasicSqlUDT udt) {
+          return udt.createWithCharsetAndCollation(charset, collation);
+        }
+        return type;
+      };
 
-  public static SqlReturnTypeInference dateInference = opBinding -> {
-    Charset charset = TYPE_FACTORY.getDefaultCharset();
-    SqlCollation collation = SqlCollation.IMPLICIT;
-    RelDataType type = TYPE_FACTORY.createUDT(ExprUDT.EXPR_DATE, true);
-    if (type instanceof ExprBasicSqlUDT udt) {
-      return udt.createWithCharsetAndCollation(charset, collation);
-    }
-    return type;
-  };
+  public static SqlReturnTypeInference dateInference =
+      opBinding -> {
+        Charset charset = TYPE_FACTORY.getDefaultCharset();
+        SqlCollation collation = SqlCollation.IMPLICIT;
+        RelDataType type = TYPE_FACTORY.createUDT(ExprUDT.EXPR_DATE, true);
+        if (type instanceof ExprBasicSqlUDT udt) {
+          return udt.createWithCharsetAndCollation(charset, collation);
+        }
+        return type;
+      };
 
-  public static SqlReturnTypeInference timeInference = opBinding -> {
-    //return TYPE_FACTORY.createUDT(ExprUDT.EXPR_TIME, true);
-    Charset charset = TYPE_FACTORY.getDefaultCharset();
-    SqlCollation collation = SqlCollation.IMPLICIT;
-    RelDataType type = TYPE_FACTORY.createUDT(ExprUDT.EXPR_TIME, true);
-    if (type instanceof ExprBasicSqlUDT udt) {
-      return udt.createWithCharsetAndCollation(charset, collation);
-    }
-    return type;
-  };
+  public static SqlReturnTypeInference timeInference =
+      opBinding -> {
+        // return TYPE_FACTORY.createUDT(ExprUDT.EXPR_TIME, true);
+        Charset charset = TYPE_FACTORY.getDefaultCharset();
+        SqlCollation collation = SqlCollation.IMPLICIT;
+        RelDataType type = TYPE_FACTORY.createUDT(ExprUDT.EXPR_TIME, true);
+        if (type instanceof ExprBasicSqlUDT udt) {
+          return udt.createWithCharsetAndCollation(charset, collation);
+        }
+        return type;
+      };
 
   public static RelDataType nullableTimeUDT = TYPE_FACTORY.createUDT(ExprUDT.EXPR_TIME, true);
   public static RelDataType nullableDateUDT = TYPE_FACTORY.createUDT(ExprUDT.EXPR_DATE, true);
-  public static RelDataType nullableTimestampUDT = TYPE_FACTORY.createUDT(ExprUDT.EXPR_TIMESTAMP, true);
+  public static RelDataType nullableTimestampUDT =
+      TYPE_FACTORY.createUDT(ExprUDT.EXPR_TIMESTAMP, true);
 
-  public static RelDataType getNullableTimeUDTWithCharset(){
+  public static RelDataType getNullableTimeUDTWithCharset() {
     Charset charset = TYPE_FACTORY.getDefaultCharset();
     SqlCollation collation = SqlCollation.IMPLICIT;
     RelDataType type = TYPE_FACTORY.createUDT(ExprUDT.EXPR_TIME, true);
@@ -102,7 +105,7 @@ public class OpenSearchTypeFactory extends JavaTypeFactoryImpl {
     return type;
   }
 
-  public static RelDataType getNullableTimestampUDTWithCharset(){
+  public static RelDataType getNullableTimestampUDTWithCharset() {
     Charset charset = TYPE_FACTORY.getDefaultCharset();
     SqlCollation collation = SqlCollation.IMPLICIT;
     RelDataType type = TYPE_FACTORY.createUDT(ExprUDT.EXPR_TIMESTAMP, true);
@@ -112,7 +115,7 @@ public class OpenSearchTypeFactory extends JavaTypeFactoryImpl {
     return type;
   }
 
-  public static RelDataType getNullableDateUDTWithCharset(){
+  public static RelDataType getNullableDateUDTWithCharset() {
     Charset charset = TYPE_FACTORY.getDefaultCharset();
     SqlCollation collation = SqlCollation.IMPLICIT;
     RelDataType type = TYPE_FACTORY.createUDT(ExprUDT.EXPR_DATE, true);

--- a/core/src/main/java/org/opensearch/sql/calcite/utils/UserDefinedFunctionUtils.java
+++ b/core/src/main/java/org/opensearch/sql/calcite/utils/UserDefinedFunctionUtils.java
@@ -10,13 +10,11 @@ import static org.opensearch.sql.calcite.utils.OpenSearchTypeFactory.nullableTim
 import static org.opensearch.sql.calcite.utils.OpenSearchTypeFactory.nullableTimestampUDT;
 import static org.opensearch.sql.utils.DateTimeFormatters.DATE_TIME_FORMATTER_VARIABLE_NANOS_OPTIONAL;
 
-import java.time.Clock;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.ZoneId;
-import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
 import java.util.ArrayList;
@@ -29,7 +27,6 @@ import org.apache.calcite.linq4j.tree.Types;
 import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rel.type.RelDataTypeFactory;
 import org.apache.calcite.rex.RexBuilder;
-import org.apache.calcite.rex.RexLiteral;
 import org.apache.calcite.rex.RexNode;
 import org.apache.calcite.schema.ScalarFunction;
 import org.apache.calcite.schema.impl.AggregateFunctionImpl;
@@ -168,7 +165,7 @@ public class UserDefinedFunctionUtils {
     return opBinding -> {
       RelDataType operandType0 = opBinding.getOperandType(0);
       if (operandType0 instanceof ExprBasicSqlUDT) {
-        if (operandType0 instanceof ExprDateType || operandType0 instanceof ExprTimeStampType){
+        if (operandType0 instanceof ExprDateType || operandType0 instanceof ExprTimeStampType) {
           return nullableTimestampUDT;
         } else if (operandType0 instanceof ExprTimeType) {
           return nullableTimeUDT;
@@ -180,10 +177,10 @@ public class UserDefinedFunctionUtils {
       return switch (typeName) {
         case DATE, TIMESTAMP ->
         // Return TIMESTAMP
-                nullableTimestampUDT;
+        nullableTimestampUDT;
         case TIME ->
         // Return TIME
-                nullableTimeUDT;
+        nullableTimeUDT;
         default -> throw new IllegalArgumentException("Unsupported type: " + typeName);
       };
     };
@@ -203,7 +200,6 @@ public class UserDefinedFunctionUtils {
       return opBinding.getTypeFactory().createTypeWithNullability(relDataType, true);
     };
   }
-
 
   static RelDataType createNullableReturnType(
       RelDataTypeFactory typeFactory, SqlTypeName sqlTypeName) {
@@ -337,13 +333,16 @@ public class UserDefinedFunctionUtils {
     if (candidate.getType() instanceof ExprBasicSqlUDT) {
       ExprBasicSqlUDT dateType = (ExprBasicSqlUDT) candidate.getType();
       ExprType udtType = dateType.getExprType();
-      List<RexNode> preprocessArgs = List.of(candidate, rexBuilder.makeFlag(PreprocessForUDTFunction.getInputType(udtType)));
+      List<RexNode> preprocessArgs =
+          List.of(candidate, rexBuilder.makeFlag(PreprocessForUDTFunction.getInputType(udtType)));
 
-      RexNode calciteTypeArgument = rexBuilder.makeCall(
+      RexNode calciteTypeArgument =
+          rexBuilder.makeCall(
               TransferUserDefinedFunction(
-                      PreprocessForUDTFunction.class,
-                      "PREPROCESS",
-                      PreprocessForUDTFunction.getSqlReturnTypeInference(udtType)), preprocessArgs);
+                  PreprocessForUDTFunction.class,
+                  "PREPROCESS",
+                  PreprocessForUDTFunction.getSqlReturnTypeInference(udtType)),
+              preprocessArgs);
       return calciteTypeArgument;
     } else {
       return candidate;
@@ -367,8 +366,8 @@ public class UserDefinedFunctionUtils {
   public static FunctionProperties restoreFunctionProperties(Object timestampStr) {
     String expression = (String) timestampStr;
     Instant parsed = Instant.parse(expression);
-    FunctionProperties functionProperties = new FunctionProperties(parsed, ZoneId.systemDefault(), QueryType.PPL);
+    FunctionProperties functionProperties =
+        new FunctionProperties(parsed, ZoneId.systemDefault(), QueryType.PPL);
     return functionProperties;
   }
-
 }

--- a/core/src/main/java/org/opensearch/sql/calcite/utils/datetime/InstantUtils.java
+++ b/core/src/main/java/org/opensearch/sql/calcite/utils/datetime/InstantUtils.java
@@ -5,12 +5,12 @@
 
 package org.opensearch.sql.calcite.utils.datetime;
 
+import static org.opensearch.sql.expression.datetime.DateTimeFunctions.exprDateTimeNoTimezone;
+
 import java.time.*;
 import org.apache.calcite.sql.type.SqlTypeName;
 import org.opensearch.sql.data.model.ExprStringValue;
 import org.opensearch.sql.data.model.ExprValue;
-
-import static org.opensearch.sql.expression.datetime.DateTimeFunctions.exprDateTimeNoTimezone;
 
 public interface InstantUtils {
 
@@ -61,22 +61,23 @@ public interface InstantUtils {
    * @param sqlTypeName type of the internalDatetime
    * @return Instant that represents the given internalDatetime
    */
-  static Instant convertToInstant(Object candidate, SqlTypeName sqlTypeName, boolean onlyForTimestamp) {
+  static Instant convertToInstant(
+      Object candidate, SqlTypeName sqlTypeName, boolean onlyForTimestamp) {
     Instant dateTimeBase = null;
     if (candidate instanceof String) {
       String timestampExpression = (String) candidate;
       if (onlyForTimestamp) {
         ExprValue timestampExpr = exprDateTimeNoTimezone(new ExprStringValue(timestampExpression));
-        if (timestampExpr.isNull()){
-          throw new IllegalArgumentException("Cannot convert " + timestampExpression + " to Instant");
+        if (timestampExpr.isNull()) {
+          throw new IllegalArgumentException(
+              "Cannot convert " + timestampExpression + " to Instant");
         } else {
           dateTimeBase = timestampExpr.timestampValue();
         }
       } else {
         dateTimeBase = InstantUtils.fromStringExpr(timestampExpression);
       }
-    }
-    else {
+    } else {
       switch (sqlTypeName) {
         case DATE:
           dateTimeBase = InstantUtils.fromInternalDate((int) candidate);

--- a/core/src/main/java/org/opensearch/sql/expression/datetime/DateTimeFunctions.java
+++ b/core/src/main/java/org/opensearch/sql/expression/datetime/DateTimeFunctions.java
@@ -34,7 +34,7 @@ import static org.opensearch.sql.utils.DateTimeFormatters.DATE_FORMATTER_SINGLE_
 import static org.opensearch.sql.utils.DateTimeFormatters.DATE_FORMATTER_SINGLE_DIGIT_YEAR;
 import static org.opensearch.sql.utils.DateTimeFormatters.DATE_TIME_FORMATTER_LONG_YEAR;
 import static org.opensearch.sql.utils.DateTimeFormatters.DATE_TIME_FORMATTER_SHORT_YEAR;
-import static org.opensearch.sql.utils.DateTimeFormatters.DATE_TIME_FORMATTER_STRICT_WITH_TZ;
+import static org.opensearch.sql.utils.DateTimeFormatters.DATE_TIME_FORMATTER_WITH_TZ;
 import static org.opensearch.sql.utils.DateTimeFormatters.FULL_DATE_LENGTH;
 import static org.opensearch.sql.utils.DateTimeFormatters.NO_YEAR_DATE_LENGTH;
 import static org.opensearch.sql.utils.DateTimeFormatters.SHORT_DATE_LENGTH;
@@ -1348,7 +1348,7 @@ public class DateTimeFunctions {
 
     try {
       LocalDateTime ldtFormatted =
-          LocalDateTime.parse(timestamp.stringValue(), DATE_TIME_FORMATTER_STRICT_WITH_TZ);
+          LocalDateTime.parse(timestamp.stringValue(), DATE_TIME_FORMATTER_WITH_TZ);
       if (timeZone.isNull()) {
         return new ExprTimestampValue(ldtFormatted);
       }
@@ -1364,7 +1364,7 @@ public class DateTimeFunctions {
 
     try {
       ZonedDateTime zdtWithZoneOffset =
-          ZonedDateTime.parse(timestamp.stringValue(), DATE_TIME_FORMATTER_STRICT_WITH_TZ);
+          ZonedDateTime.parse(timestamp.stringValue(), DATE_TIME_FORMATTER_WITH_TZ);
       ZoneId fromTZ = zdtWithZoneOffset.getZone();
 
       tz = new ExprTimestampValue(zdtWithZoneOffset.toLocalDateTime());

--- a/integ-test/src/test/java/org/opensearch/sql/calcite/CalciteBuiltinDatetimeFunctionInvalidIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/calcite/CalciteBuiltinDatetimeFunctionInvalidIT.java
@@ -1,1451 +1,1676 @@
 package org.opensearch.sql.calcite;
 
+import static org.opensearch.sql.legacy.TestsConstants.TEST_INDEX_DATE_FORMATS_WITH_NULL;
+
+import java.io.IOException;
 import org.json.JSONObject;
 import org.junit.jupiter.api.Test;
 import org.opensearch.sql.calcite.standalone.CalcitePPLIntegTestCase;
 import org.opensearch.sql.legacy.SQLIntegTestCase;
 
-import java.io.IOException;
-
-import static org.opensearch.sql.legacy.TestsConstants.TEST_INDEX_DATE_FORMATS_WITH_NULL;
-
 public class CalciteBuiltinDatetimeFunctionInvalidIT extends CalcitePPLIntegTestCase {
-    @Override
-    public void init() throws IOException {
-        super.init();
-        loadIndex(SQLIntegTestCase.Index.STATE_COUNTRY);
-        loadIndex(SQLIntegTestCase.Index.STATE_COUNTRY_WITH_NULL);
-        loadIndex(SQLIntegTestCase.Index.DATE_FORMATS);
-        loadIndex(SQLIntegTestCase.Index.DATE_FORMATS_WITH_NULL);
-    }
-
-    @Test
-    public void testYearWeekInvalid() {
-        assertThrows(Exception.class, () -> {
-            // Code that should throw the exception
-            JSONObject actual =
-                    executeQuery(
-                            String.format(
-                                    "source=%s  | eval `YEARWEEK('2020-08-26')` = YEARWEEK('2020-15-26')",
-                                    TEST_INDEX_DATE_FORMATS_WITH_NULL));
-        });
-    }
-
-    @Test
-    public void testYearInvalid() {
-        assertThrows(Exception.class, () -> {
-            // Code that should throw the exception
-            JSONObject actual =
-                    executeQuery(
-                            String.format(
-                                    "source=%s  | eval a = YEAR('2020-15-26')",
-                                    TEST_INDEX_DATE_FORMATS_WITH_NULL));
-        });
-        assertThrows(Exception.class, () -> {
-            // Code that should throw the exception
-            JSONObject actual =
-                    executeQuery(
-                            String.format(
-                                    "source=%s  | eval a = YEAR('2020-12-26 25:00:00')",
-                                    TEST_INDEX_DATE_FORMATS_WITH_NULL));
-        });
-    }
-
-    @Test
-    public void testWeekInvalid() {
-        assertThrows(Exception.class, () -> {
-            // Code that should throw the exception
-            JSONObject actual =
-                    executeQuery(
-                            String.format(
-                                    "source=%s  | eval a = WEEK('2020-15-26')",
-                                    TEST_INDEX_DATE_FORMATS_WITH_NULL));
-        });
-        assertThrows(Exception.class, () -> {
-            // Code that should throw the exception
-            JSONObject actual =
-                    executeQuery(
-                            String.format(
-                                    "source=%s  | eval a = WEEK('2020-12-26 25:00:00')",
-                                    TEST_INDEX_DATE_FORMATS_WITH_NULL));
-        });
-    }
-    @Test
-    public void testTO_SECONDSInvalid() {
-
-        assertThrows(Exception.class, () -> {
-            JSONObject actual =
-                    executeQuery(
-                            String.format(
-                                    "source=%s  |  eval a=TO_SECONDS('2025-13-02') | fields a",
-                                    TEST_INDEX_DATE_FORMATS_WITH_NULL));
-        });
-
-        assertThrows(Exception.class, () -> {
-            JSONObject actual =
-                    executeQuery(
-                            String.format(
-                                    "source=%s  |  eval a=TO_SECONDS('16:00:61') | fields a",
-                                    TEST_INDEX_DATE_FORMATS_WITH_NULL));
-        });
-
-        assertThrows(Exception.class, () -> {
-            JSONObject actual =
-                    executeQuery(
-                            String.format(
-                                    "source=%s  |  eval a=TO_SECONDS('2025-12-01 15:02:61') | fields a",
-                                    TEST_INDEX_DATE_FORMATS_WITH_NULL));
-        });
-
-    }
-
-
-    @Test
-    public void testDATEInvalid() {
-
-        assertThrows(Exception.class, () -> {
-            JSONObject actual =
-                    executeQuery(
-                            String.format(
-                                    "source=%s  |  eval a=DATE('2025-13-02') | fields a",
-                                    TEST_INDEX_DATE_FORMATS_WITH_NULL));
-        });
-
-        assertThrows(Exception.class, () -> {
-            JSONObject actual =
-                    executeQuery(
-                            String.format(
-                                    "source=%s  |  eval a=DATE('16:00:61') | fields a",
-                                    TEST_INDEX_DATE_FORMATS_WITH_NULL));
-        });
-
-        assertThrows(Exception.class, () -> {
-            JSONObject actual =
-                    executeQuery(
-                            String.format(
-                                    "source=%s  |  eval a=DATE('2025-12-01 15:02:61') | fields a",
-                                    TEST_INDEX_DATE_FORMATS_WITH_NULL));
-        });
-
-    }
-
-
-    @Test
-    public void testTIMEInvalid() {
-
-        assertThrows(Exception.class, () -> {
-            JSONObject actual =
-                    executeQuery(
-                            String.format(
-                                    "source=%s  |  eval a=TIME('2025-13-02') | fields a",
-                                    TEST_INDEX_DATE_FORMATS_WITH_NULL));
-        });
-
-        assertThrows(Exception.class, () -> {
-            JSONObject actual =
-                    executeQuery(
-                            String.format(
-                                    "source=%s  |  eval a=TIME('16:00:61') | fields a",
-                                    TEST_INDEX_DATE_FORMATS_WITH_NULL));
-        });
-
-        assertThrows(Exception.class, () -> {
-            JSONObject actual =
-                    executeQuery(
-                            String.format(
-                                    "source=%s  |  eval a=TIME('2025-12-01 15:02:61') | fields a",
-                                    TEST_INDEX_DATE_FORMATS_WITH_NULL));
-        });
-
-    }
-
-
-    @Test
-    public void testDAYInvalid() {
-
-        assertThrows(Exception.class, () -> {
-            JSONObject actual =
-                    executeQuery(
-                            String.format(
-                                    "source=%s  |  eval a=DAY('2025-13-02') | fields a",
-                                    TEST_INDEX_DATE_FORMATS_WITH_NULL));
-        });
-
-        assertThrows(Exception.class, () -> {
-            JSONObject actual =
-                    executeQuery(
-                            String.format(
-                                    "source=%s  |  eval a=DAY('16:00:61') | fields a",
-                                    TEST_INDEX_DATE_FORMATS_WITH_NULL));
-        });
-
-        assertThrows(Exception.class, () -> {
-            JSONObject actual =
-                    executeQuery(
-                            String.format(
-                                    "source=%s  |  eval a=DAY('2025-12-01 15:02:61') | fields a",
-                                    TEST_INDEX_DATE_FORMATS_WITH_NULL));
-        });
-
-    }
-
-
-    @Test
-    public void testDAYNAMEInvalid() {
-
-        assertThrows(Exception.class, () -> {
-            JSONObject actual =
-                    executeQuery(
-                            String.format(
-                                    "source=%s  |  eval a=DAYNAME('2025-13-02') | fields a",
-                                    TEST_INDEX_DATE_FORMATS_WITH_NULL));
-        });
-
-        assertThrows(Exception.class, () -> {
-            JSONObject actual =
-                    executeQuery(
-                            String.format(
-                                    "source=%s  |  eval a=DAYNAME('16:00:61') | fields a",
-                                    TEST_INDEX_DATE_FORMATS_WITH_NULL));
-        });
-
-        assertThrows(Exception.class, () -> {
-            JSONObject actual =
-                    executeQuery(
-                            String.format(
-                                    "source=%s  |  eval a=DAYNAME('2025-12-01 15:02:61') | fields a",
-                                    TEST_INDEX_DATE_FORMATS_WITH_NULL));
-        });
-
-    }
-
-
-    @Test
-    public void testDAYOFMONTHInvalid() {
-
-        assertThrows(Exception.class, () -> {
-            JSONObject actual =
-                    executeQuery(
-                            String.format(
-                                    "source=%s  |  eval a=DAYOFMONTH('2025-13-02') | fields a",
-                                    TEST_INDEX_DATE_FORMATS_WITH_NULL));
-        });
-
-        assertThrows(Exception.class, () -> {
-            JSONObject actual =
-                    executeQuery(
-                            String.format(
-                                    "source=%s  |  eval a=DAYOFMONTH('16:00:61') | fields a",
-                                    TEST_INDEX_DATE_FORMATS_WITH_NULL));
-        });
-
-        assertThrows(Exception.class, () -> {
-            JSONObject actual =
-                    executeQuery(
-                            String.format(
-                                    "source=%s  |  eval a=DAYOFMONTH('2025-12-01 15:02:61') | fields a",
-                                    TEST_INDEX_DATE_FORMATS_WITH_NULL));
-        });
-
-    }
-
-
-    @Test
-    public void testDAY_OF_MONTHInvalid() {
-
-        assertThrows(Exception.class, () -> {
-            JSONObject actual =
-                    executeQuery(
-                            String.format(
-                                    "source=%s  |  eval a=DAY_OF_MONTH('2025-13-02') | fields a",
-                                    TEST_INDEX_DATE_FORMATS_WITH_NULL));
-        });
-
-        assertThrows(Exception.class, () -> {
-            JSONObject actual =
-                    executeQuery(
-                            String.format(
-                                    "source=%s  |  eval a=DAY_OF_MONTH('16:00:61') | fields a",
-                                    TEST_INDEX_DATE_FORMATS_WITH_NULL));
-        });
-
-        assertThrows(Exception.class, () -> {
-            JSONObject actual =
-                    executeQuery(
-                            String.format(
-                                    "source=%s  |  eval a=DAY_OF_MONTH('2025-12-01 15:02:61') | fields a",
-                                    TEST_INDEX_DATE_FORMATS_WITH_NULL));
-        });
-
-    }
-
-
-    @Test
-    public void testDAYOFWEEKInvalid() {
-
-        assertThrows(Exception.class, () -> {
-            JSONObject actual =
-                    executeQuery(
-                            String.format(
-                                    "source=%s  |  eval a=DAYOFWEEK('2025-13-02') | fields a",
-                                    TEST_INDEX_DATE_FORMATS_WITH_NULL));
-        });
-
-        assertThrows(Exception.class, () -> {
-            JSONObject actual =
-                    executeQuery(
-                            String.format(
-                                    "source=%s  |  eval a=DAYOFWEEK('16:00:61') | fields a",
-                                    TEST_INDEX_DATE_FORMATS_WITH_NULL));
-        });
-
-        assertThrows(Exception.class, () -> {
-            JSONObject actual =
-                    executeQuery(
-                            String.format(
-                                    "source=%s  |  eval a=DAYOFWEEK('2025-12-01 15:02:61') | fields a",
-                                    TEST_INDEX_DATE_FORMATS_WITH_NULL));
-        });
-
-        assertThrows(Exception.class, () -> {
-            JSONObject actual =
-                    executeQuery(
-                            String.format(
-                                    "source=%s  |  eval a=DAYOFWEEK('2025-13-02') | fields a",
-                                    TEST_INDEX_DATE_FORMATS_WITH_NULL));
-        });
-
-        assertThrows(Exception.class, () -> {
-            JSONObject actual =
-                    executeQuery(
-                            String.format(
-                                    "source=%s  |  eval a=DAYOFWEEK('16:00:61') | fields a",
-                                    TEST_INDEX_DATE_FORMATS_WITH_NULL));
-        });
-
-        assertThrows(Exception.class, () -> {
-            JSONObject actual =
-                    executeQuery(
-                            String.format(
-                                    "source=%s  |  eval a=DAYOFWEEK('2025-12-01 15:02:61') | fields a",
-                                    TEST_INDEX_DATE_FORMATS_WITH_NULL));
-        });
-
-    }
-
-
-    @Test
-    public void testDAY_OF_WEEKInvalid() {
-
-        assertThrows(Exception.class, () -> {
-            JSONObject actual =
-                    executeQuery(
-                            String.format(
-                                    "source=%s  |  eval a=DAY_OF_WEEK('2025-13-02') | fields a",
-                                    TEST_INDEX_DATE_FORMATS_WITH_NULL));
-        });
-
-        assertThrows(Exception.class, () -> {
-            JSONObject actual =
-                    executeQuery(
-                            String.format(
-                                    "source=%s  |  eval a=DAY_OF_WEEK('16:00:61') | fields a",
-                                    TEST_INDEX_DATE_FORMATS_WITH_NULL));
-        });
-
-        assertThrows(Exception.class, () -> {
-            JSONObject actual =
-                    executeQuery(
-                            String.format(
-                                    "source=%s  |  eval a=DAY_OF_WEEK('2025-12-01 15:02:61') | fields a",
-                                    TEST_INDEX_DATE_FORMATS_WITH_NULL));
-        });
-
-    }
-
-
-    @Test
-    public void testDAYOFYEARInvalid() {
-
-        assertThrows(Exception.class, () -> {
-            JSONObject actual =
-                    executeQuery(
-                            String.format(
-                                    "source=%s  |  eval a=DAYOFYEAR('2025-13-02') | fields a",
-                                    TEST_INDEX_DATE_FORMATS_WITH_NULL));
-        });
-
-        assertThrows(Exception.class, () -> {
-            JSONObject actual =
-                    executeQuery(
-                            String.format(
-                                    "source=%s  |  eval a=DAYOFYEAR('16:00:61') | fields a",
-                                    TEST_INDEX_DATE_FORMATS_WITH_NULL));
-        });
-
-        assertThrows(Exception.class, () -> {
-            JSONObject actual =
-                    executeQuery(
-                            String.format(
-                                    "source=%s  |  eval a=DAYOFYEAR('2025-12-01 15:02:61') | fields a",
-                                    TEST_INDEX_DATE_FORMATS_WITH_NULL));
-        });
-
-    }
-
-
-    @Test
-    public void testDAY_OF_YEARInvalid() {
-
-        assertThrows(Exception.class, () -> {
-            JSONObject actual =
-                    executeQuery(
-                            String.format(
-                                    "source=%s  |  eval a=DAY_OF_YEAR('2025-13-02') | fields a",
-                                    TEST_INDEX_DATE_FORMATS_WITH_NULL));
-        });
-
-        assertThrows(Exception.class, () -> {
-            JSONObject actual =
-                    executeQuery(
-                            String.format(
-                                    "source=%s  |  eval a=DAY_OF_YEAR('16:00:61') | fields a",
-                                    TEST_INDEX_DATE_FORMATS_WITH_NULL));
-        });
-
-        assertThrows(Exception.class, () -> {
-            JSONObject actual =
-                    executeQuery(
-                            String.format(
-                                    "source=%s  |  eval a=DAY_OF_YEAR('2025-12-01 15:02:61') | fields a",
-                                    TEST_INDEX_DATE_FORMATS_WITH_NULL));
-        });
-
-    }
-
-
-    @Test
-    public void testHOURInvalid() {
-
-        assertThrows(Exception.class, () -> {
-            JSONObject actual =
-                    executeQuery(
-                            String.format(
-                                    "source=%s  |  eval a=HOUR('2025-13-02') | fields a",
-                                    TEST_INDEX_DATE_FORMATS_WITH_NULL));
-        });
-
-        assertThrows(Exception.class, () -> {
-            JSONObject actual =
-                    executeQuery(
-                            String.format(
-                                    "source=%s  |  eval a=HOUR('16:00:61') | fields a",
-                                    TEST_INDEX_DATE_FORMATS_WITH_NULL));
-        });
-
-        assertThrows(Exception.class, () -> {
-            JSONObject actual =
-                    executeQuery(
-                            String.format(
-                                    "source=%s  |  eval a=HOUR('2025-12-01 15:02:61') | fields a",
-                                    TEST_INDEX_DATE_FORMATS_WITH_NULL));
-        });
-
-    }
-
-
-    @Test
-    public void testHOUR_OF_DAYInvalid() {
-
-        assertThrows(Exception.class, () -> {
-            JSONObject actual =
-                    executeQuery(
-                            String.format(
-                                    "source=%s  |  eval a=HOUR_OF_DAY('2025-13-02') | fields a",
-                                    TEST_INDEX_DATE_FORMATS_WITH_NULL));
-        });
-
-        assertThrows(Exception.class, () -> {
-            JSONObject actual =
-                    executeQuery(
-                            String.format(
-                                    "source=%s  |  eval a=HOUR_OF_DAY('16:00:61') | fields a",
-                                    TEST_INDEX_DATE_FORMATS_WITH_NULL));
-        });
-
-        assertThrows(Exception.class, () -> {
-            JSONObject actual =
-                    executeQuery(
-                            String.format(
-                                    "source=%s  |  eval a=HOUR_OF_DAY('2025-12-01 15:02:61') | fields a",
-                                    TEST_INDEX_DATE_FORMATS_WITH_NULL));
-        });
-
-    }
-
-
-    @Test
-    public void testLAST_DAYInvalid() {
-
-        assertThrows(Exception.class, () -> {
-            JSONObject actual =
-                    executeQuery(
-                            String.format(
-                                    "source=%s  |  eval a=LAST_DAY('2025-13-02') | fields a",
-                                    TEST_INDEX_DATE_FORMATS_WITH_NULL));
-        });
-
-        assertThrows(Exception.class, () -> {
-            JSONObject actual =
-                    executeQuery(
-                            String.format(
-                                    "source=%s  |  eval a=LAST_DAY('16:00:61') | fields a",
-                                    TEST_INDEX_DATE_FORMATS_WITH_NULL));
-        });
-
-        assertThrows(Exception.class, () -> {
-            JSONObject actual =
-                    executeQuery(
-                            String.format(
-                                    "source=%s  |  eval a=LAST_DAY('2025-12-01 15:02:61') | fields a",
-                                    TEST_INDEX_DATE_FORMATS_WITH_NULL));
-        });
-
-    }
-
-
-    @Test
-    public void testMINUTEInvalid() {
-
-        assertThrows(Exception.class, () -> {
-            JSONObject actual =
-                    executeQuery(
-                            String.format(
-                                    "source=%s  |  eval a=MINUTE('2025-13-02') | fields a",
-                                    TEST_INDEX_DATE_FORMATS_WITH_NULL));
-        });
-
-        assertThrows(Exception.class, () -> {
-            JSONObject actual =
-                    executeQuery(
-                            String.format(
-                                    "source=%s  |  eval a=MINUTE('16:00:61') | fields a",
-                                    TEST_INDEX_DATE_FORMATS_WITH_NULL));
-        });
-
-        assertThrows(Exception.class, () -> {
-            JSONObject actual =
-                    executeQuery(
-                            String.format(
-                                    "source=%s  |  eval a=MINUTE('2025-12-01 15:02:61') | fields a",
-                                    TEST_INDEX_DATE_FORMATS_WITH_NULL));
-        });
-
-    }
-
-
-    @Test
-    public void testMINUTE_OF_DAYInvalid() {
-
-        assertThrows(Exception.class, () -> {
-            JSONObject actual =
-                    executeQuery(
-                            String.format(
-                                    "source=%s  |  eval a=MINUTE_OF_DAY('2025-13-02') | fields a",
-                                    TEST_INDEX_DATE_FORMATS_WITH_NULL));
-        });
-
-        assertThrows(Exception.class, () -> {
-            JSONObject actual =
-                    executeQuery(
-                            String.format(
-                                    "source=%s  |  eval a=MINUTE_OF_DAY('16:00:61') | fields a",
-                                    TEST_INDEX_DATE_FORMATS_WITH_NULL));
-        });
-
-        assertThrows(Exception.class, () -> {
-            JSONObject actual =
-                    executeQuery(
-                            String.format(
-                                    "source=%s  |  eval a=MINUTE_OF_DAY('2025-12-01 15:02:61') | fields a",
-                                    TEST_INDEX_DATE_FORMATS_WITH_NULL));
-        });
-
-    }
-
-
-    @Test
-    public void testMINUTE_OF_HOURInvalid() {
-
-        assertThrows(Exception.class, () -> {
-            JSONObject actual =
-                    executeQuery(
-                            String.format(
-                                    "source=%s  |  eval a=MINUTE_OF_HOUR('2025-13-02') | fields a",
-                                    TEST_INDEX_DATE_FORMATS_WITH_NULL));
-        });
-
-        assertThrows(Exception.class, () -> {
-            JSONObject actual =
-                    executeQuery(
-                            String.format(
-                                    "source=%s  |  eval a=MINUTE_OF_HOUR('16:00:61') | fields a",
-                                    TEST_INDEX_DATE_FORMATS_WITH_NULL));
-        });
-
-        assertThrows(Exception.class, () -> {
-            JSONObject actual =
-                    executeQuery(
-                            String.format(
-                                    "source=%s  |  eval a=MINUTE_OF_HOUR('2025-12-01 15:02:61') | fields a",
-                                    TEST_INDEX_DATE_FORMATS_WITH_NULL));
-        });
-
-    }
-
-
-    @Test
-    public void testMONTHInvalid() {
-
-        assertThrows(Exception.class, () -> {
-            JSONObject actual =
-                    executeQuery(
-                            String.format(
-                                    "source=%s  |  eval a=MONTH('2025-13-02') | fields a",
-                                    TEST_INDEX_DATE_FORMATS_WITH_NULL));
-        });
-
-        assertThrows(Exception.class, () -> {
-            JSONObject actual =
-                    executeQuery(
-                            String.format(
-                                    "source=%s  |  eval a=MONTH('16:00:61') | fields a",
-                                    TEST_INDEX_DATE_FORMATS_WITH_NULL));
-        });
-
-        assertThrows(Exception.class, () -> {
-            JSONObject actual =
-                    executeQuery(
-                            String.format(
-                                    "source=%s  |  eval a=MONTH('2025-12-01 15:02:61') | fields a",
-                                    TEST_INDEX_DATE_FORMATS_WITH_NULL));
-        });
-
-    }
-
-
-    @Test
-    public void testMONTH_OF_YEARInvalid() {
-
-        assertThrows(Exception.class, () -> {
-            JSONObject actual =
-                    executeQuery(
-                            String.format(
-                                    "source=%s  |  eval a=MONTH_OF_YEAR('2025-13-02') | fields a",
-                                    TEST_INDEX_DATE_FORMATS_WITH_NULL));
-        });
-
-        assertThrows(Exception.class, () -> {
-            JSONObject actual =
-                    executeQuery(
-                            String.format(
-                                    "source=%s  |  eval a=MONTH_OF_YEAR('16:00:61') | fields a",
-                                    TEST_INDEX_DATE_FORMATS_WITH_NULL));
-        });
-
-        assertThrows(Exception.class, () -> {
-            JSONObject actual =
-                    executeQuery(
-                            String.format(
-                                    "source=%s  |  eval a=MONTH_OF_YEAR('2025-12-01 15:02:61') | fields a",
-                                    TEST_INDEX_DATE_FORMATS_WITH_NULL));
-        });
-
-    }
-
-
-    @Test
-    public void testMONTHNAMEInvalid() {
-
-        assertThrows(Exception.class, () -> {
-            JSONObject actual =
-                    executeQuery(
-                            String.format(
-                                    "source=%s  |  eval a=MONTHNAME('2025-13-02') | fields a",
-                                    TEST_INDEX_DATE_FORMATS_WITH_NULL));
-        });
-
-        assertThrows(Exception.class, () -> {
-            JSONObject actual =
-                    executeQuery(
-                            String.format(
-                                    "source=%s  |  eval a=MONTHNAME('16:00:61') | fields a",
-                                    TEST_INDEX_DATE_FORMATS_WITH_NULL));
-        });
-
-        assertThrows(Exception.class, () -> {
-            JSONObject actual =
-                    executeQuery(
-                            String.format(
-                                    "source=%s  |  eval a=MONTHNAME('2025-12-01 15:02:61') | fields a",
-                                    TEST_INDEX_DATE_FORMATS_WITH_NULL));
-        });
-
-    }
-
-
-    @Test
-    public void testQUARTERInvalid() {
-
-        assertThrows(Exception.class, () -> {
-            JSONObject actual =
-                    executeQuery(
-                            String.format(
-                                    "source=%s  |  eval a=QUARTER('2025-13-02') | fields a",
-                                    TEST_INDEX_DATE_FORMATS_WITH_NULL));
-        });
-
-        assertThrows(Exception.class, () -> {
-            JSONObject actual =
-                    executeQuery(
-                            String.format(
-                                    "source=%s  |  eval a=QUARTER('16:00:61') | fields a",
-                                    TEST_INDEX_DATE_FORMATS_WITH_NULL));
-        });
-
-        assertThrows(Exception.class, () -> {
-            JSONObject actual =
-                    executeQuery(
-                            String.format(
-                                    "source=%s  |  eval a=QUARTER('2025-12-01 15:02:61') | fields a",
-                                    TEST_INDEX_DATE_FORMATS_WITH_NULL));
-        });
-
-    }
-
-
-    @Test
-    public void testSECONDInvalid() {
-
-        assertThrows(Exception.class, () -> {
-            JSONObject actual =
-                    executeQuery(
-                            String.format(
-                                    "source=%s  |  eval a=SECOND('2025-13-02') | fields a",
-                                    TEST_INDEX_DATE_FORMATS_WITH_NULL));
-        });
-
-        assertThrows(Exception.class, () -> {
-            JSONObject actual =
-                    executeQuery(
-                            String.format(
-                                    "source=%s  |  eval a=SECOND('16:00:61') | fields a",
-                                    TEST_INDEX_DATE_FORMATS_WITH_NULL));
-        });
-
-        assertThrows(Exception.class, () -> {
-            JSONObject actual =
-                    executeQuery(
-                            String.format(
-                                    "source=%s  |  eval a=SECOND('2025-12-01 15:02:61') | fields a",
-                                    TEST_INDEX_DATE_FORMATS_WITH_NULL));
-        });
-
-    }
-
-
-    @Test
-    public void testSECOND_OF_MINUTEInvalid() {
-
-        assertThrows(Exception.class, () -> {
-            JSONObject actual =
-                    executeQuery(
-                            String.format(
-                                    "source=%s  |  eval a=SECOND_OF_MINUTE('2025-13-02') | fields a",
-                                    TEST_INDEX_DATE_FORMATS_WITH_NULL));
-        });
-
-        assertThrows(Exception.class, () -> {
-            JSONObject actual =
-                    executeQuery(
-                            String.format(
-                                    "source=%s  |  eval a=SECOND_OF_MINUTE('16:00:61') | fields a",
-                                    TEST_INDEX_DATE_FORMATS_WITH_NULL));
-        });
-
-        assertThrows(Exception.class, () -> {
-            JSONObject actual =
-                    executeQuery(
-                            String.format(
-                                    "source=%s  |  eval a=SECOND_OF_MINUTE('2025-12-01 15:02:61') | fields a",
-                                    TEST_INDEX_DATE_FORMATS_WITH_NULL));
-        });
-
-    }
-
-
-    @Test
-    public void testTIME_TO_SECInvalid() {
-
-        assertThrows(Exception.class, () -> {
-            JSONObject actual =
-                    executeQuery(
-                            String.format(
-                                    "source=%s  |  eval a=TIME_TO_SEC('2025-13-02') | fields a",
-                                    TEST_INDEX_DATE_FORMATS_WITH_NULL));
-        });
-
-        assertThrows(Exception.class, () -> {
-            JSONObject actual =
-                    executeQuery(
-                            String.format(
-                                    "source=%s  |  eval a=TIME_TO_SEC('16:00:61') | fields a",
-                                    TEST_INDEX_DATE_FORMATS_WITH_NULL));
-        });
-
-        assertThrows(Exception.class, () -> {
-            JSONObject actual =
-                    executeQuery(
-                            String.format(
-                                    "source=%s  |  eval a=TIME_TO_SEC('2025-12-01 15:02:61') | fields a",
-                                    TEST_INDEX_DATE_FORMATS_WITH_NULL));
-        });
-
-    }
-
-
-    @Test
-    public void testTIMESTAMPInvalid() {
-
-        assertThrows(Exception.class, () -> {
-            JSONObject actual =
-                    executeQuery(
-                            String.format(
-                                    "source=%s  |  eval a=TIMESTAMP('2025-13-02') | fields a",
-                                    TEST_INDEX_DATE_FORMATS_WITH_NULL));
-        });
-
-        assertThrows(Exception.class, () -> {
-            JSONObject actual =
-                    executeQuery(
-                            String.format(
-                                    "source=%s  |  eval a=TIMESTAMP('16:00:61') | fields a",
-                                    TEST_INDEX_DATE_FORMATS_WITH_NULL));
-        });
-
-        assertThrows(Exception.class, () -> {
-            JSONObject actual =
-                    executeQuery(
-                            String.format(
-                                    "source=%s  |  eval a=TIMESTAMP('2025-12-01 15:02:61') | fields a",
-                                    TEST_INDEX_DATE_FORMATS_WITH_NULL));
-        });
-
-        assertThrows(Exception.class, () -> {
-            JSONObject actual =
-                    executeQuery(
-                            String.format(
-                                    "source=%s  |  eval a=TIMESTAMP('2025-13-02') | fields a",
-                                    TEST_INDEX_DATE_FORMATS_WITH_NULL));
-        });
-
-        assertThrows(Exception.class, () -> {
-            JSONObject actual =
-                    executeQuery(
-                            String.format(
-                                    "source=%s  |  eval a=TIMESTAMP('16:00:61') | fields a",
-                                    TEST_INDEX_DATE_FORMATS_WITH_NULL));
-        });
-
-        assertThrows(Exception.class, () -> {
-            JSONObject actual =
-                    executeQuery(
-                            String.format(
-                                    "source=%s  |  eval a=TIMESTAMP('2025-12-01 15:02:61') | fields a",
-                                    TEST_INDEX_DATE_FORMATS_WITH_NULL));
-        });
-
-        assertThrows(Exception.class, () -> {
-            JSONObject actual =
-                    executeQuery(
-                            String.format(
-                                    "source=%s  |  eval a=TIMESTAMP('2025-13-02', '2025-13-02') | fields a",
-                                    TEST_INDEX_DATE_FORMATS_WITH_NULL));
-        });
-
-        assertThrows(Exception.class, () -> {
-            JSONObject actual =
-                    executeQuery(
-                            String.format(
-                                    "source=%s  |  eval a=TIMESTAMP('16:00:61', '16:00:61') | fields a",
-                                    TEST_INDEX_DATE_FORMATS_WITH_NULL));
-        });
-
-        assertThrows(Exception.class, () -> {
-            JSONObject actual =
-                    executeQuery(
-                            String.format(
-                                    "source=%s  |  eval a=TIMESTAMP('2025-12-01 15:02:61', '2025-12-01 15:02:61') | fields a",
-                                    TEST_INDEX_DATE_FORMATS_WITH_NULL));
-        });
-
-    }
-
-
-    @Test
-    public void testTO_DAYSInvalid() {
-
-        assertThrows(Exception.class, () -> {
-            JSONObject actual =
-                    executeQuery(
-                            String.format(
-                                    "source=%s  |  eval a=TO_DAYS('2025-13-02') | fields a",
-                                    TEST_INDEX_DATE_FORMATS_WITH_NULL));
-        });
-
-        assertThrows(Exception.class, () -> {
-            JSONObject actual =
-                    executeQuery(
-                            String.format(
-                                    "source=%s  |  eval a=TO_DAYS('16:00:61') | fields a",
-                                    TEST_INDEX_DATE_FORMATS_WITH_NULL));
-        });
-
-        assertThrows(Exception.class, () -> {
-            JSONObject actual =
-                    executeQuery(
-                            String.format(
-                                    "source=%s  |  eval a=TO_DAYS('2025-12-01 15:02:61') | fields a",
-                                    TEST_INDEX_DATE_FORMATS_WITH_NULL));
-        });
-
-    }
-
-
-    @Test
-    public void testYEARInvalid() {
-
-        assertThrows(Exception.class, () -> {
-            JSONObject actual =
-                    executeQuery(
-                            String.format(
-                                    "source=%s  |  eval a=YEAR('2025-13-02') | fields a",
-                                    TEST_INDEX_DATE_FORMATS_WITH_NULL));
-        });
-
-        assertThrows(Exception.class, () -> {
-            JSONObject actual =
-                    executeQuery(
-                            String.format(
-                                    "source=%s  |  eval a=YEAR('16:00:61') | fields a",
-                                    TEST_INDEX_DATE_FORMATS_WITH_NULL));
-        });
-
-        assertThrows(Exception.class, () -> {
-            JSONObject actual =
-                    executeQuery(
-                            String.format(
-                                    "source=%s  |  eval a=YEAR('2025-12-01 15:02:61') | fields a",
-                                    TEST_INDEX_DATE_FORMATS_WITH_NULL));
-        });
-
-    }
-
-
-    @Test
-    public void testWEEKInvalid() {
-
-        assertThrows(Exception.class, () -> {
-            JSONObject actual =
-                    executeQuery(
-                            String.format(
-                                    "source=%s  |  eval a=WEEK('2025-13-02') | fields a",
-                                    TEST_INDEX_DATE_FORMATS_WITH_NULL));
-        });
-
-        assertThrows(Exception.class, () -> {
-            JSONObject actual =
-                    executeQuery(
-                            String.format(
-                                    "source=%s  |  eval a=WEEK('16:00:61') | fields a",
-                                    TEST_INDEX_DATE_FORMATS_WITH_NULL));
-        });
-
-        assertThrows(Exception.class, () -> {
-            JSONObject actual =
-                    executeQuery(
-                            String.format(
-                                    "source=%s  |  eval a=WEEK('2025-12-01 15:02:61') | fields a",
-                                    TEST_INDEX_DATE_FORMATS_WITH_NULL));
-        });
-
-    }
-
-
-    @Test
-    public void testWEEK_OF_YEARInvalid() {
-
-        assertThrows(Exception.class, () -> {
-            JSONObject actual =
-                    executeQuery(
-                            String.format(
-                                    "source=%s  |  eval a=WEEK_OF_YEAR('2025-13-02') | fields a",
-                                    TEST_INDEX_DATE_FORMATS_WITH_NULL));
-        });
-
-        assertThrows(Exception.class, () -> {
-            JSONObject actual =
-                    executeQuery(
-                            String.format(
-                                    "source=%s  |  eval a=WEEK_OF_YEAR('16:00:61') | fields a",
-                                    TEST_INDEX_DATE_FORMATS_WITH_NULL));
-        });
-
-        assertThrows(Exception.class, () -> {
-            JSONObject actual =
-                    executeQuery(
-                            String.format(
-                                    "source=%s  |  eval a=WEEK_OF_YEAR('2025-12-01 15:02:61') | fields a",
-                                    TEST_INDEX_DATE_FORMATS_WITH_NULL));
-        });
-
-    }
-
-
-    @Test
-    public void testWEEKDAYInvalid() {
-
-        assertThrows(Exception.class, () -> {
-            JSONObject actual =
-                    executeQuery(
-                            String.format(
-                                    "source=%s  |  eval a=WEEKDAY('2025-13-02') | fields a",
-                                    TEST_INDEX_DATE_FORMATS_WITH_NULL));
-        });
-
-        assertThrows(Exception.class, () -> {
-            JSONObject actual =
-                    executeQuery(
-                            String.format(
-                                    "source=%s  |  eval a=WEEKDAY('16:00:61') | fields a",
-                                    TEST_INDEX_DATE_FORMATS_WITH_NULL));
-        });
-
-        assertThrows(Exception.class, () -> {
-            JSONObject actual =
-                    executeQuery(
-                            String.format(
-                                    "source=%s  |  eval a=WEEKDAY('2025-12-01 15:02:61') | fields a",
-                                    TEST_INDEX_DATE_FORMATS_WITH_NULL));
-        });
-
-    }
-
-
-    @Test
-    public void testYEARWEEKInvalid() {
-
-        assertThrows(Exception.class, () -> {
-            JSONObject actual =
-                    executeQuery(
-                            String.format(
-                                    "source=%s  |  eval a=YEARWEEK('2025-13-02') | fields a",
-                                    TEST_INDEX_DATE_FORMATS_WITH_NULL));
-        });
-
-        assertThrows(Exception.class, () -> {
-            JSONObject actual =
-                    executeQuery(
-                            String.format(
-                                    "source=%s  |  eval a=YEARWEEK('16:00:61') | fields a",
-                                    TEST_INDEX_DATE_FORMATS_WITH_NULL));
-        });
-
-        assertThrows(Exception.class, () -> {
-            JSONObject actual =
-                    executeQuery(
-                            String.format(
-                                    "source=%s  |  eval a=YEARWEEK('2025-12-01 15:02:61') | fields a",
-                                    TEST_INDEX_DATE_FORMATS_WITH_NULL));
-        });
-
-    }
-
-
-    @Test
-    public void testADDTATEInvalid() {
-
-        assertThrows(Exception.class, () -> {
-            JSONObject actual =
-                    executeQuery(
-                            String.format(
-                                    "source=%s  |  eval a=ADDTATE('2025-13-02', INTERVAL 1 HOUR) | fields a",
-                                    TEST_INDEX_DATE_FORMATS_WITH_NULL));
-        });
-
-        assertThrows(Exception.class, () -> {
-            JSONObject actual =
-                    executeQuery(
-                            String.format(
-                                    "source=%s  |  eval a=ADDTATE('16:00:61', INTERVAL 1 HOUR) | fields a",
-                                    TEST_INDEX_DATE_FORMATS_WITH_NULL));
-        });
-
-        assertThrows(Exception.class, () -> {
-            JSONObject actual =
-                    executeQuery(
-                            String.format(
-                                    "source=%s  |  eval a=ADDTATE('2025-12-01 15:02:61', INTERVAL 1 HOUR) | fields a",
-                                    TEST_INDEX_DATE_FORMATS_WITH_NULL));
-        });
-
-        assertThrows(Exception.class, () -> {
-            JSONObject actual =
-                    executeQuery(
-                            String.format(
-                                    "source=%s  |  eval a=ADDTATE('2025-13-02', 1) | fields a",
-                                    TEST_INDEX_DATE_FORMATS_WITH_NULL));
-        });
-
-        assertThrows(Exception.class, () -> {
-            JSONObject actual =
-                    executeQuery(
-                            String.format(
-                                    "source=%s  |  eval a=ADDTATE('16:00:61', 1) | fields a",
-                                    TEST_INDEX_DATE_FORMATS_WITH_NULL));
-        });
-
-        assertThrows(Exception.class, () -> {
-            JSONObject actual =
-                    executeQuery(
-                            String.format(
-                                    "source=%s  |  eval a=ADDTATE('2025-12-01 15:02:61', 1) | fields a",
-                                    TEST_INDEX_DATE_FORMATS_WITH_NULL));
-        });
-
-    }
-
-
-    @Test
-    public void testADDTIMEInvalid() {
-
-        assertThrows(Exception.class, () -> {
-            JSONObject actual =
-                    executeQuery(
-                            String.format(
-                                    "source=%s  |  eval a=ADDTIME('2025-13-02', '2025-13-02') | fields a",
-                                    TEST_INDEX_DATE_FORMATS_WITH_NULL));
-        });
-
-        assertThrows(Exception.class, () -> {
-            JSONObject actual =
-                    executeQuery(
-                            String.format(
-                                    "source=%s  |  eval a=ADDTIME('16:00:61', '16:00:61') | fields a",
-                                    TEST_INDEX_DATE_FORMATS_WITH_NULL));
-        });
-
-        assertThrows(Exception.class, () -> {
-            JSONObject actual =
-                    executeQuery(
-                            String.format(
-                                    "source=%s  |  eval a=ADDTIME('2025-12-01 15:02:61', '2025-12-01 15:02:61') | fields a",
-                                    TEST_INDEX_DATE_FORMATS_WITH_NULL));
-        });
-
-    }
-
-    @Test
-    public void testDATE_ADDInvalid() {
-
-        assertThrows(Exception.class, () -> {
-            JSONObject actual =
-                    executeQuery(
-                            String.format(
-                                    "source=%s  |  eval a=DATE_ADD('2025-13-02', INTERVAL 1 HOUR) | fields a",
-                                    TEST_INDEX_DATE_FORMATS_WITH_NULL));
-        });
-
-        assertThrows(Exception.class, () -> {
-            JSONObject actual =
-                    executeQuery(
-                            String.format(
-                                    "source=%s  |  eval a=DATE_ADD('16:00:61', INTERVAL 1 HOUR) | fields a",
-                                    TEST_INDEX_DATE_FORMATS_WITH_NULL));
-        });
-
-        assertThrows(Exception.class, () -> {
-            JSONObject actual =
-                    executeQuery(
-                            String.format(
-                                    "source=%s  |  eval a=DATE_ADD('2025-12-01 15:02:61', INTERVAL 1 HOUR) | fields a",
-                                    TEST_INDEX_DATE_FORMATS_WITH_NULL));
-        });
-
-    }
-
-
-    @Test
-    public void testDATE_SUBInvalid() {
-
-        assertThrows(Exception.class, () -> {
-            JSONObject actual =
-                    executeQuery(
-                            String.format(
-                                    "source=%s  |  eval a=DATE_SUB('2025-13-02', INTERVAL 1 HOUR) | fields a",
-                                    TEST_INDEX_DATE_FORMATS_WITH_NULL));
-        });
-
-        assertThrows(Exception.class, () -> {
-            JSONObject actual =
-                    executeQuery(
-                            String.format(
-                                    "source=%s  |  eval a=DATE_SUB('16:00:61', INTERVAL 1 HOUR) | fields a",
-                                    TEST_INDEX_DATE_FORMATS_WITH_NULL));
-        });
-
-        assertThrows(Exception.class, () -> {
-            JSONObject actual =
-                    executeQuery(
-                            String.format(
-                                    "source=%s  |  eval a=DATE_SUB('2025-12-01 15:02:61', INTERVAL 1 HOUR) | fields a",
-                                    TEST_INDEX_DATE_FORMATS_WITH_NULL));
-        });
-
-    }
-
-
-    @Test
-    public void testDATEDIFFInvalid() {
-
-        assertThrows(Exception.class, () -> {
-            JSONObject actual =
-                    executeQuery(
-                            String.format(
-                                    "source=%s  |  eval a=DATEDIFF('2025-13-02', '2025-13-02') | fields a",
-                                    TEST_INDEX_DATE_FORMATS_WITH_NULL));
-        });
-
-        assertThrows(Exception.class, () -> {
-            JSONObject actual =
-                    executeQuery(
-                            String.format(
-                                    "source=%s  |  eval a=DATEDIFF('16:00:61', '16:00:61') | fields a",
-                                    TEST_INDEX_DATE_FORMATS_WITH_NULL));
-        });
-
-        assertThrows(Exception.class, () -> {
-            JSONObject actual =
-                    executeQuery(
-                            String.format(
-                                    "source=%s  |  eval a=DATEDIFF('2025-12-01 15:02:61', '2025-12-01 15:02:61') | fields a",
-                                    TEST_INDEX_DATE_FORMATS_WITH_NULL));
-        });
-
-    }
-
-
-    @Test
-    public void testSUBDATEInvalid() {
-
-        assertThrows(Exception.class, () -> {
-            JSONObject actual =
-                    executeQuery(
-                            String.format(
-                                    "source=%s  |  eval a=SUBDATE('2025-13-02', INTERVAL 1 HOUR) | fields a",
-                                    TEST_INDEX_DATE_FORMATS_WITH_NULL));
-        });
-
-        assertThrows(Exception.class, () -> {
-            JSONObject actual =
-                    executeQuery(
-                            String.format(
-                                    "source=%s  |  eval a=SUBDATE('16:00:61', INTERVAL 1 HOUR) | fields a",
-                                    TEST_INDEX_DATE_FORMATS_WITH_NULL));
-        });
-
-        assertThrows(Exception.class, () -> {
-            JSONObject actual =
-                    executeQuery(
-                            String.format(
-                                    "source=%s  |  eval a=SUBDATE('2025-12-01 15:02:61', INTERVAL 1 HOUR) | fields a",
-                                    TEST_INDEX_DATE_FORMATS_WITH_NULL));
-        });
-
-        assertThrows(Exception.class, () -> {
-            JSONObject actual =
-                    executeQuery(
-                            String.format(
-                                    "source=%s  |  eval a=SUBDATE('2025-13-02', 1) | fields a",
-                                    TEST_INDEX_DATE_FORMATS_WITH_NULL));
-        });
-
-        assertThrows(Exception.class, () -> {
-            JSONObject actual =
-                    executeQuery(
-                            String.format(
-                                    "source=%s  |  eval a=SUBDATE('16:00:61', 1) | fields a",
-                                    TEST_INDEX_DATE_FORMATS_WITH_NULL));
-        });
-
-        assertThrows(Exception.class, () -> {
-            JSONObject actual =
-                    executeQuery(
-                            String.format(
-                                    "source=%s  |  eval a=SUBDATE('2025-12-01 15:02:61', 1) | fields a",
-                                    TEST_INDEX_DATE_FORMATS_WITH_NULL));
-        });
-
-    }
-
-
-    @Test
-    public void testSUBTIMEInvalid() {
-
-        assertThrows(Exception.class, () -> {
-            JSONObject actual =
-                    executeQuery(
-                            String.format(
-                                    "source=%s  |  eval a=SUBTIME('2025-13-02', '2025-13-02') | fields a",
-                                    TEST_INDEX_DATE_FORMATS_WITH_NULL));
-        });
-
-        assertThrows(Exception.class, () -> {
-            JSONObject actual =
-                    executeQuery(
-                            String.format(
-                                    "source=%s  |  eval a=SUBTIME('16:00:61', '16:00:61') | fields a",
-                                    TEST_INDEX_DATE_FORMATS_WITH_NULL));
-        });
-
-        assertThrows(Exception.class, () -> {
-            JSONObject actual =
-                    executeQuery(
-                            String.format(
-                                    "source=%s  |  eval a=SUBTIME('2025-12-01 15:02:61', '2025-12-01 15:02:61') | fields a",
-                                    TEST_INDEX_DATE_FORMATS_WITH_NULL));
-        });
-
-    }
-
-
-    @Test
-    public void testTIMESTAMPADDInvalid() {
-
-        assertThrows(Exception.class, () -> {
-            JSONObject actual =
-                    executeQuery(
-                            String.format(
-                                    "source=%s  |  eval a=TIMESTAMPADD(INTERVAL 1 HOUR, 1, '2025-13-02') | fields a",
-                                    TEST_INDEX_DATE_FORMATS_WITH_NULL));
-        });
-
-        assertThrows(Exception.class, () -> {
-            JSONObject actual =
-                    executeQuery(
-                            String.format(
-                                    "source=%s  |  eval a=TIMESTAMPADD(INTERVAL 1 HOUR, 1, '16:00:61') | fields a",
-                                    TEST_INDEX_DATE_FORMATS_WITH_NULL));
-        });
-
-        assertThrows(Exception.class, () -> {
-            JSONObject actual =
-                    executeQuery(
-                            String.format(
-                                    "source=%s  |  eval a=TIMESTAMPADD(INTERVAL 1 HOUR, 1, '2025-12-01 15:02:61') | fields a",
-                                    TEST_INDEX_DATE_FORMATS_WITH_NULL));
-        });
-
-    }
-
-
-    @Test
-    public void testTIMESTAMPDIFFInvalid() {
-
-        assertThrows(Exception.class, () -> {
-            JSONObject actual =
-                    executeQuery(
-                            String.format(
-                                    "source=%s  |  eval a=TIMESTAMPDIFF(INTERVAL 1 HOUR, '2025-13-02', '2025-13-02') | fields a",
-                                    TEST_INDEX_DATE_FORMATS_WITH_NULL));
-        });
-
-        assertThrows(Exception.class, () -> {
-            JSONObject actual =
-                    executeQuery(
-                            String.format(
-                                    "source=%s  |  eval a=TIMESTAMPDIFF(INTERVAL 1 HOUR, '16:00:61', '16:00:61') | fields a",
-                                    TEST_INDEX_DATE_FORMATS_WITH_NULL));
-        });
-
-        assertThrows(Exception.class, () -> {
-            JSONObject actual =
-                    executeQuery(
-                            String.format(
-                                    "source=%s  |  eval a=TIMESTAMPDIFF(INTERVAL 1 HOUR, '2025-12-01 15:02:61', '2025-12-01 15:02:61') | fields a",
-                                    TEST_INDEX_DATE_FORMATS_WITH_NULL));
-        });
-
-    }
-
-
-    @Test
-    public void testDATE_FORMATInvalid() {
-
-        assertThrows(Exception.class, () -> {
-            JSONObject actual =
-                    executeQuery(
-                            String.format(
-                                    "source=%s  |  eval a=DATE_FORMAT('2025-13-02', '2025-13-02') | fields a",
-                                    TEST_INDEX_DATE_FORMATS_WITH_NULL));
-        });
-
-        assertThrows(Exception.class, () -> {
-            JSONObject actual =
-                    executeQuery(
-                            String.format(
-                                    "source=%s  |  eval a=DATE_FORMAT('16:00:61', '16:00:61') | fields a",
-                                    TEST_INDEX_DATE_FORMATS_WITH_NULL));
-        });
-
-        assertThrows(Exception.class, () -> {
-            JSONObject actual =
-                    executeQuery(
-                            String.format(
-                                    "source=%s  |  eval a=DATE_FORMAT('2025-12-01 15:02:61', '2025-12-01 15:02:61') | fields a",
-                                    TEST_INDEX_DATE_FORMATS_WITH_NULL));
-        });
-
-    }
-
-
-    @Test
-    public void testTIME_FORMATInvalid() {
-
-        assertThrows(Exception.class, () -> {
-            JSONObject actual =
-                    executeQuery(
-                            String.format(
-                                    "source=%s  |  eval a=TIME_FORMAT('2025-13-02', '2025-13-02') | fields a",
-                                    TEST_INDEX_DATE_FORMATS_WITH_NULL));
-        });
-
-        assertThrows(Exception.class, () -> {
-            JSONObject actual =
-                    executeQuery(
-                            String.format(
-                                    "source=%s  |  eval a=TIME_FORMAT('16:00:61', '16:00:61') | fields a",
-                                    TEST_INDEX_DATE_FORMATS_WITH_NULL));
-        });
-
-        assertThrows(Exception.class, () -> {
-            JSONObject actual =
-                    executeQuery(
-                            String.format(
-                                    "source=%s  |  eval a=TIME_FORMAT('2025-12-01 15:02:61', '2025-12-01 15:02:61') | fields a",
-                                    TEST_INDEX_DATE_FORMATS_WITH_NULL));
-        });
-
-    }
-
+  @Override
+  public void init() throws IOException {
+    super.init();
+    loadIndex(SQLIntegTestCase.Index.STATE_COUNTRY);
+    loadIndex(SQLIntegTestCase.Index.STATE_COUNTRY_WITH_NULL);
+    loadIndex(SQLIntegTestCase.Index.DATE_FORMATS);
+    loadIndex(SQLIntegTestCase.Index.DATE_FORMATS_WITH_NULL);
+  }
+
+  @Test
+  public void testYearWeekInvalid() {
+    assertThrows(
+        Exception.class,
+        () -> {
+          // Code that should throw the exception
+          JSONObject actual =
+              executeQuery(
+                  String.format(
+                      "source=%s  | eval `YEARWEEK('2020-08-26')` = YEARWEEK('2020-15-26')",
+                      TEST_INDEX_DATE_FORMATS_WITH_NULL));
+        });
+  }
+
+  @Test
+  public void testYearInvalid() {
+    assertThrows(
+        Exception.class,
+        () -> {
+          // Code that should throw the exception
+          JSONObject actual =
+              executeQuery(
+                  String.format(
+                      "source=%s  | eval a = YEAR('2020-15-26')",
+                      TEST_INDEX_DATE_FORMATS_WITH_NULL));
+        });
+    assertThrows(
+        Exception.class,
+        () -> {
+          // Code that should throw the exception
+          JSONObject actual =
+              executeQuery(
+                  String.format(
+                      "source=%s  | eval a = YEAR('2020-12-26 25:00:00')",
+                      TEST_INDEX_DATE_FORMATS_WITH_NULL));
+        });
+  }
+
+  @Test
+  public void testWeekInvalid() {
+    assertThrows(
+        Exception.class,
+        () -> {
+          // Code that should throw the exception
+          JSONObject actual =
+              executeQuery(
+                  String.format(
+                      "source=%s  | eval a = WEEK('2020-15-26')",
+                      TEST_INDEX_DATE_FORMATS_WITH_NULL));
+        });
+    assertThrows(
+        Exception.class,
+        () -> {
+          // Code that should throw the exception
+          JSONObject actual =
+              executeQuery(
+                  String.format(
+                      "source=%s  | eval a = WEEK('2020-12-26 25:00:00')",
+                      TEST_INDEX_DATE_FORMATS_WITH_NULL));
+        });
+  }
+
+  @Test
+  public void testTO_SECONDSInvalid() {
+
+    assertThrows(
+        Exception.class,
+        () -> {
+          JSONObject actual =
+              executeQuery(
+                  String.format(
+                      "source=%s  |  eval a=TO_SECONDS('2025-13-02') | fields a",
+                      TEST_INDEX_DATE_FORMATS_WITH_NULL));
+        });
+
+    assertThrows(
+        Exception.class,
+        () -> {
+          JSONObject actual =
+              executeQuery(
+                  String.format(
+                      "source=%s  |  eval a=TO_SECONDS('16:00:61') | fields a",
+                      TEST_INDEX_DATE_FORMATS_WITH_NULL));
+        });
+
+    assertThrows(
+        Exception.class,
+        () -> {
+          JSONObject actual =
+              executeQuery(
+                  String.format(
+                      "source=%s  |  eval a=TO_SECONDS('2025-12-01 15:02:61') | fields a",
+                      TEST_INDEX_DATE_FORMATS_WITH_NULL));
+        });
+  }
+
+  @Test
+  public void testDATEInvalid() {
+
+    assertThrows(
+        Exception.class,
+        () -> {
+          JSONObject actual =
+              executeQuery(
+                  String.format(
+                      "source=%s  |  eval a=DATE('2025-13-02') | fields a",
+                      TEST_INDEX_DATE_FORMATS_WITH_NULL));
+        });
+
+    assertThrows(
+        Exception.class,
+        () -> {
+          JSONObject actual =
+              executeQuery(
+                  String.format(
+                      "source=%s  |  eval a=DATE('16:00:61') | fields a",
+                      TEST_INDEX_DATE_FORMATS_WITH_NULL));
+        });
+
+    assertThrows(
+        Exception.class,
+        () -> {
+          JSONObject actual =
+              executeQuery(
+                  String.format(
+                      "source=%s  |  eval a=DATE('2025-12-01 15:02:61') | fields a",
+                      TEST_INDEX_DATE_FORMATS_WITH_NULL));
+        });
+  }
+
+  @Test
+  public void testTIMEInvalid() {
+
+    assertThrows(
+        Exception.class,
+        () -> {
+          JSONObject actual =
+              executeQuery(
+                  String.format(
+                      "source=%s  |  eval a=TIME('2025-13-02') | fields a",
+                      TEST_INDEX_DATE_FORMATS_WITH_NULL));
+        });
+
+    assertThrows(
+        Exception.class,
+        () -> {
+          JSONObject actual =
+              executeQuery(
+                  String.format(
+                      "source=%s  |  eval a=TIME('16:00:61') | fields a",
+                      TEST_INDEX_DATE_FORMATS_WITH_NULL));
+        });
+
+    assertThrows(
+        Exception.class,
+        () -> {
+          JSONObject actual =
+              executeQuery(
+                  String.format(
+                      "source=%s  |  eval a=TIME('2025-12-01 15:02:61') | fields a",
+                      TEST_INDEX_DATE_FORMATS_WITH_NULL));
+        });
+  }
+
+  @Test
+  public void testDAYInvalid() {
+
+    assertThrows(
+        Exception.class,
+        () -> {
+          JSONObject actual =
+              executeQuery(
+                  String.format(
+                      "source=%s  |  eval a=DAY('2025-13-02') | fields a",
+                      TEST_INDEX_DATE_FORMATS_WITH_NULL));
+        });
+
+    assertThrows(
+        Exception.class,
+        () -> {
+          JSONObject actual =
+              executeQuery(
+                  String.format(
+                      "source=%s  |  eval a=DAY('16:00:61') | fields a",
+                      TEST_INDEX_DATE_FORMATS_WITH_NULL));
+        });
+
+    assertThrows(
+        Exception.class,
+        () -> {
+          JSONObject actual =
+              executeQuery(
+                  String.format(
+                      "source=%s  |  eval a=DAY('2025-12-01 15:02:61') | fields a",
+                      TEST_INDEX_DATE_FORMATS_WITH_NULL));
+        });
+  }
+
+  @Test
+  public void testDAYNAMEInvalid() {
+
+    assertThrows(
+        Exception.class,
+        () -> {
+          JSONObject actual =
+              executeQuery(
+                  String.format(
+                      "source=%s  |  eval a=DAYNAME('2025-13-02') | fields a",
+                      TEST_INDEX_DATE_FORMATS_WITH_NULL));
+        });
+
+    assertThrows(
+        Exception.class,
+        () -> {
+          JSONObject actual =
+              executeQuery(
+                  String.format(
+                      "source=%s  |  eval a=DAYNAME('16:00:61') | fields a",
+                      TEST_INDEX_DATE_FORMATS_WITH_NULL));
+        });
+
+    assertThrows(
+        Exception.class,
+        () -> {
+          JSONObject actual =
+              executeQuery(
+                  String.format(
+                      "source=%s  |  eval a=DAYNAME('2025-12-01 15:02:61') | fields a",
+                      TEST_INDEX_DATE_FORMATS_WITH_NULL));
+        });
+  }
+
+  @Test
+  public void testDAYOFMONTHInvalid() {
+
+    assertThrows(
+        Exception.class,
+        () -> {
+          JSONObject actual =
+              executeQuery(
+                  String.format(
+                      "source=%s  |  eval a=DAYOFMONTH('2025-13-02') | fields a",
+                      TEST_INDEX_DATE_FORMATS_WITH_NULL));
+        });
+
+    assertThrows(
+        Exception.class,
+        () -> {
+          JSONObject actual =
+              executeQuery(
+                  String.format(
+                      "source=%s  |  eval a=DAYOFMONTH('16:00:61') | fields a",
+                      TEST_INDEX_DATE_FORMATS_WITH_NULL));
+        });
+
+    assertThrows(
+        Exception.class,
+        () -> {
+          JSONObject actual =
+              executeQuery(
+                  String.format(
+                      "source=%s  |  eval a=DAYOFMONTH('2025-12-01 15:02:61') | fields a",
+                      TEST_INDEX_DATE_FORMATS_WITH_NULL));
+        });
+  }
+
+  @Test
+  public void testDAY_OF_MONTHInvalid() {
+
+    assertThrows(
+        Exception.class,
+        () -> {
+          JSONObject actual =
+              executeQuery(
+                  String.format(
+                      "source=%s  |  eval a=DAY_OF_MONTH('2025-13-02') | fields a",
+                      TEST_INDEX_DATE_FORMATS_WITH_NULL));
+        });
+
+    assertThrows(
+        Exception.class,
+        () -> {
+          JSONObject actual =
+              executeQuery(
+                  String.format(
+                      "source=%s  |  eval a=DAY_OF_MONTH('16:00:61') | fields a",
+                      TEST_INDEX_DATE_FORMATS_WITH_NULL));
+        });
+
+    assertThrows(
+        Exception.class,
+        () -> {
+          JSONObject actual =
+              executeQuery(
+                  String.format(
+                      "source=%s  |  eval a=DAY_OF_MONTH('2025-12-01 15:02:61') | fields a",
+                      TEST_INDEX_DATE_FORMATS_WITH_NULL));
+        });
+  }
+
+  @Test
+  public void testDAYOFWEEKInvalid() {
+
+    assertThrows(
+        Exception.class,
+        () -> {
+          JSONObject actual =
+              executeQuery(
+                  String.format(
+                      "source=%s  |  eval a=DAYOFWEEK('2025-13-02') | fields a",
+                      TEST_INDEX_DATE_FORMATS_WITH_NULL));
+        });
+
+    assertThrows(
+        Exception.class,
+        () -> {
+          JSONObject actual =
+              executeQuery(
+                  String.format(
+                      "source=%s  |  eval a=DAYOFWEEK('16:00:61') | fields a",
+                      TEST_INDEX_DATE_FORMATS_WITH_NULL));
+        });
+
+    assertThrows(
+        Exception.class,
+        () -> {
+          JSONObject actual =
+              executeQuery(
+                  String.format(
+                      "source=%s  |  eval a=DAYOFWEEK('2025-12-01 15:02:61') | fields a",
+                      TEST_INDEX_DATE_FORMATS_WITH_NULL));
+        });
+
+    assertThrows(
+        Exception.class,
+        () -> {
+          JSONObject actual =
+              executeQuery(
+                  String.format(
+                      "source=%s  |  eval a=DAYOFWEEK('2025-13-02') | fields a",
+                      TEST_INDEX_DATE_FORMATS_WITH_NULL));
+        });
+
+    assertThrows(
+        Exception.class,
+        () -> {
+          JSONObject actual =
+              executeQuery(
+                  String.format(
+                      "source=%s  |  eval a=DAYOFWEEK('16:00:61') | fields a",
+                      TEST_INDEX_DATE_FORMATS_WITH_NULL));
+        });
+
+    assertThrows(
+        Exception.class,
+        () -> {
+          JSONObject actual =
+              executeQuery(
+                  String.format(
+                      "source=%s  |  eval a=DAYOFWEEK('2025-12-01 15:02:61') | fields a",
+                      TEST_INDEX_DATE_FORMATS_WITH_NULL));
+        });
+  }
+
+  @Test
+  public void testDAY_OF_WEEKInvalid() {
+
+    assertThrows(
+        Exception.class,
+        () -> {
+          JSONObject actual =
+              executeQuery(
+                  String.format(
+                      "source=%s  |  eval a=DAY_OF_WEEK('2025-13-02') | fields a",
+                      TEST_INDEX_DATE_FORMATS_WITH_NULL));
+        });
+
+    assertThrows(
+        Exception.class,
+        () -> {
+          JSONObject actual =
+              executeQuery(
+                  String.format(
+                      "source=%s  |  eval a=DAY_OF_WEEK('16:00:61') | fields a",
+                      TEST_INDEX_DATE_FORMATS_WITH_NULL));
+        });
+
+    assertThrows(
+        Exception.class,
+        () -> {
+          JSONObject actual =
+              executeQuery(
+                  String.format(
+                      "source=%s  |  eval a=DAY_OF_WEEK('2025-12-01 15:02:61') | fields a",
+                      TEST_INDEX_DATE_FORMATS_WITH_NULL));
+        });
+  }
+
+  @Test
+  public void testDAYOFYEARInvalid() {
+
+    assertThrows(
+        Exception.class,
+        () -> {
+          JSONObject actual =
+              executeQuery(
+                  String.format(
+                      "source=%s  |  eval a=DAYOFYEAR('2025-13-02') | fields a",
+                      TEST_INDEX_DATE_FORMATS_WITH_NULL));
+        });
+
+    assertThrows(
+        Exception.class,
+        () -> {
+          JSONObject actual =
+              executeQuery(
+                  String.format(
+                      "source=%s  |  eval a=DAYOFYEAR('16:00:61') | fields a",
+                      TEST_INDEX_DATE_FORMATS_WITH_NULL));
+        });
+
+    assertThrows(
+        Exception.class,
+        () -> {
+          JSONObject actual =
+              executeQuery(
+                  String.format(
+                      "source=%s  |  eval a=DAYOFYEAR('2025-12-01 15:02:61') | fields a",
+                      TEST_INDEX_DATE_FORMATS_WITH_NULL));
+        });
+  }
+
+  @Test
+  public void testDAY_OF_YEARInvalid() {
+
+    assertThrows(
+        Exception.class,
+        () -> {
+          JSONObject actual =
+              executeQuery(
+                  String.format(
+                      "source=%s  |  eval a=DAY_OF_YEAR('2025-13-02') | fields a",
+                      TEST_INDEX_DATE_FORMATS_WITH_NULL));
+        });
+
+    assertThrows(
+        Exception.class,
+        () -> {
+          JSONObject actual =
+              executeQuery(
+                  String.format(
+                      "source=%s  |  eval a=DAY_OF_YEAR('16:00:61') | fields a",
+                      TEST_INDEX_DATE_FORMATS_WITH_NULL));
+        });
+
+    assertThrows(
+        Exception.class,
+        () -> {
+          JSONObject actual =
+              executeQuery(
+                  String.format(
+                      "source=%s  |  eval a=DAY_OF_YEAR('2025-12-01 15:02:61') | fields a",
+                      TEST_INDEX_DATE_FORMATS_WITH_NULL));
+        });
+  }
+
+  @Test
+  public void testHOURInvalid() {
+
+    assertThrows(
+        Exception.class,
+        () -> {
+          JSONObject actual =
+              executeQuery(
+                  String.format(
+                      "source=%s  |  eval a=HOUR('2025-13-02') | fields a",
+                      TEST_INDEX_DATE_FORMATS_WITH_NULL));
+        });
+
+    assertThrows(
+        Exception.class,
+        () -> {
+          JSONObject actual =
+              executeQuery(
+                  String.format(
+                      "source=%s  |  eval a=HOUR('16:00:61') | fields a",
+                      TEST_INDEX_DATE_FORMATS_WITH_NULL));
+        });
+
+    assertThrows(
+        Exception.class,
+        () -> {
+          JSONObject actual =
+              executeQuery(
+                  String.format(
+                      "source=%s  |  eval a=HOUR('2025-12-01 15:02:61') | fields a",
+                      TEST_INDEX_DATE_FORMATS_WITH_NULL));
+        });
+  }
+
+  @Test
+  public void testHOUR_OF_DAYInvalid() {
+
+    assertThrows(
+        Exception.class,
+        () -> {
+          JSONObject actual =
+              executeQuery(
+                  String.format(
+                      "source=%s  |  eval a=HOUR_OF_DAY('2025-13-02') | fields a",
+                      TEST_INDEX_DATE_FORMATS_WITH_NULL));
+        });
+
+    assertThrows(
+        Exception.class,
+        () -> {
+          JSONObject actual =
+              executeQuery(
+                  String.format(
+                      "source=%s  |  eval a=HOUR_OF_DAY('16:00:61') | fields a",
+                      TEST_INDEX_DATE_FORMATS_WITH_NULL));
+        });
+
+    assertThrows(
+        Exception.class,
+        () -> {
+          JSONObject actual =
+              executeQuery(
+                  String.format(
+                      "source=%s  |  eval a=HOUR_OF_DAY('2025-12-01 15:02:61') | fields a",
+                      TEST_INDEX_DATE_FORMATS_WITH_NULL));
+        });
+  }
+
+  @Test
+  public void testLAST_DAYInvalid() {
+
+    assertThrows(
+        Exception.class,
+        () -> {
+          JSONObject actual =
+              executeQuery(
+                  String.format(
+                      "source=%s  |  eval a=LAST_DAY('2025-13-02') | fields a",
+                      TEST_INDEX_DATE_FORMATS_WITH_NULL));
+        });
+
+    assertThrows(
+        Exception.class,
+        () -> {
+          JSONObject actual =
+              executeQuery(
+                  String.format(
+                      "source=%s  |  eval a=LAST_DAY('16:00:61') | fields a",
+                      TEST_INDEX_DATE_FORMATS_WITH_NULL));
+        });
+
+    assertThrows(
+        Exception.class,
+        () -> {
+          JSONObject actual =
+              executeQuery(
+                  String.format(
+                      "source=%s  |  eval a=LAST_DAY('2025-12-01 15:02:61') | fields a",
+                      TEST_INDEX_DATE_FORMATS_WITH_NULL));
+        });
+  }
+
+  @Test
+  public void testMINUTEInvalid() {
+
+    assertThrows(
+        Exception.class,
+        () -> {
+          JSONObject actual =
+              executeQuery(
+                  String.format(
+                      "source=%s  |  eval a=MINUTE('2025-13-02') | fields a",
+                      TEST_INDEX_DATE_FORMATS_WITH_NULL));
+        });
+
+    assertThrows(
+        Exception.class,
+        () -> {
+          JSONObject actual =
+              executeQuery(
+                  String.format(
+                      "source=%s  |  eval a=MINUTE('16:00:61') | fields a",
+                      TEST_INDEX_DATE_FORMATS_WITH_NULL));
+        });
+
+    assertThrows(
+        Exception.class,
+        () -> {
+          JSONObject actual =
+              executeQuery(
+                  String.format(
+                      "source=%s  |  eval a=MINUTE('2025-12-01 15:02:61') | fields a",
+                      TEST_INDEX_DATE_FORMATS_WITH_NULL));
+        });
+  }
+
+  @Test
+  public void testMINUTE_OF_DAYInvalid() {
+
+    assertThrows(
+        Exception.class,
+        () -> {
+          JSONObject actual =
+              executeQuery(
+                  String.format(
+                      "source=%s  |  eval a=MINUTE_OF_DAY('2025-13-02') | fields a",
+                      TEST_INDEX_DATE_FORMATS_WITH_NULL));
+        });
+
+    assertThrows(
+        Exception.class,
+        () -> {
+          JSONObject actual =
+              executeQuery(
+                  String.format(
+                      "source=%s  |  eval a=MINUTE_OF_DAY('16:00:61') | fields a",
+                      TEST_INDEX_DATE_FORMATS_WITH_NULL));
+        });
+
+    assertThrows(
+        Exception.class,
+        () -> {
+          JSONObject actual =
+              executeQuery(
+                  String.format(
+                      "source=%s  |  eval a=MINUTE_OF_DAY('2025-12-01 15:02:61') | fields a",
+                      TEST_INDEX_DATE_FORMATS_WITH_NULL));
+        });
+  }
+
+  @Test
+  public void testMINUTE_OF_HOURInvalid() {
+
+    assertThrows(
+        Exception.class,
+        () -> {
+          JSONObject actual =
+              executeQuery(
+                  String.format(
+                      "source=%s  |  eval a=MINUTE_OF_HOUR('2025-13-02') | fields a",
+                      TEST_INDEX_DATE_FORMATS_WITH_NULL));
+        });
+
+    assertThrows(
+        Exception.class,
+        () -> {
+          JSONObject actual =
+              executeQuery(
+                  String.format(
+                      "source=%s  |  eval a=MINUTE_OF_HOUR('16:00:61') | fields a",
+                      TEST_INDEX_DATE_FORMATS_WITH_NULL));
+        });
+
+    assertThrows(
+        Exception.class,
+        () -> {
+          JSONObject actual =
+              executeQuery(
+                  String.format(
+                      "source=%s  |  eval a=MINUTE_OF_HOUR('2025-12-01 15:02:61') | fields a",
+                      TEST_INDEX_DATE_FORMATS_WITH_NULL));
+        });
+  }
+
+  @Test
+  public void testMONTHInvalid() {
+
+    assertThrows(
+        Exception.class,
+        () -> {
+          JSONObject actual =
+              executeQuery(
+                  String.format(
+                      "source=%s  |  eval a=MONTH('2025-13-02') | fields a",
+                      TEST_INDEX_DATE_FORMATS_WITH_NULL));
+        });
+
+    assertThrows(
+        Exception.class,
+        () -> {
+          JSONObject actual =
+              executeQuery(
+                  String.format(
+                      "source=%s  |  eval a=MONTH('16:00:61') | fields a",
+                      TEST_INDEX_DATE_FORMATS_WITH_NULL));
+        });
+
+    assertThrows(
+        Exception.class,
+        () -> {
+          JSONObject actual =
+              executeQuery(
+                  String.format(
+                      "source=%s  |  eval a=MONTH('2025-12-01 15:02:61') | fields a",
+                      TEST_INDEX_DATE_FORMATS_WITH_NULL));
+        });
+  }
+
+  @Test
+  public void testMONTH_OF_YEARInvalid() {
+
+    assertThrows(
+        Exception.class,
+        () -> {
+          JSONObject actual =
+              executeQuery(
+                  String.format(
+                      "source=%s  |  eval a=MONTH_OF_YEAR('2025-13-02') | fields a",
+                      TEST_INDEX_DATE_FORMATS_WITH_NULL));
+        });
+
+    assertThrows(
+        Exception.class,
+        () -> {
+          JSONObject actual =
+              executeQuery(
+                  String.format(
+                      "source=%s  |  eval a=MONTH_OF_YEAR('16:00:61') | fields a",
+                      TEST_INDEX_DATE_FORMATS_WITH_NULL));
+        });
+
+    assertThrows(
+        Exception.class,
+        () -> {
+          JSONObject actual =
+              executeQuery(
+                  String.format(
+                      "source=%s  |  eval a=MONTH_OF_YEAR('2025-12-01 15:02:61') | fields a",
+                      TEST_INDEX_DATE_FORMATS_WITH_NULL));
+        });
+  }
+
+  @Test
+  public void testMONTHNAMEInvalid() {
+
+    assertThrows(
+        Exception.class,
+        () -> {
+          JSONObject actual =
+              executeQuery(
+                  String.format(
+                      "source=%s  |  eval a=MONTHNAME('2025-13-02') | fields a",
+                      TEST_INDEX_DATE_FORMATS_WITH_NULL));
+        });
+
+    assertThrows(
+        Exception.class,
+        () -> {
+          JSONObject actual =
+              executeQuery(
+                  String.format(
+                      "source=%s  |  eval a=MONTHNAME('16:00:61') | fields a",
+                      TEST_INDEX_DATE_FORMATS_WITH_NULL));
+        });
+
+    assertThrows(
+        Exception.class,
+        () -> {
+          JSONObject actual =
+              executeQuery(
+                  String.format(
+                      "source=%s  |  eval a=MONTHNAME('2025-12-01 15:02:61') | fields a",
+                      TEST_INDEX_DATE_FORMATS_WITH_NULL));
+        });
+  }
+
+  @Test
+  public void testQUARTERInvalid() {
+
+    assertThrows(
+        Exception.class,
+        () -> {
+          JSONObject actual =
+              executeQuery(
+                  String.format(
+                      "source=%s  |  eval a=QUARTER('2025-13-02') | fields a",
+                      TEST_INDEX_DATE_FORMATS_WITH_NULL));
+        });
+
+    assertThrows(
+        Exception.class,
+        () -> {
+          JSONObject actual =
+              executeQuery(
+                  String.format(
+                      "source=%s  |  eval a=QUARTER('16:00:61') | fields a",
+                      TEST_INDEX_DATE_FORMATS_WITH_NULL));
+        });
+
+    assertThrows(
+        Exception.class,
+        () -> {
+          JSONObject actual =
+              executeQuery(
+                  String.format(
+                      "source=%s  |  eval a=QUARTER('2025-12-01 15:02:61') | fields a",
+                      TEST_INDEX_DATE_FORMATS_WITH_NULL));
+        });
+  }
+
+  @Test
+  public void testSECONDInvalid() {
+
+    assertThrows(
+        Exception.class,
+        () -> {
+          JSONObject actual =
+              executeQuery(
+                  String.format(
+                      "source=%s  |  eval a=SECOND('2025-13-02') | fields a",
+                      TEST_INDEX_DATE_FORMATS_WITH_NULL));
+        });
+
+    assertThrows(
+        Exception.class,
+        () -> {
+          JSONObject actual =
+              executeQuery(
+                  String.format(
+                      "source=%s  |  eval a=SECOND('16:00:61') | fields a",
+                      TEST_INDEX_DATE_FORMATS_WITH_NULL));
+        });
+
+    assertThrows(
+        Exception.class,
+        () -> {
+          JSONObject actual =
+              executeQuery(
+                  String.format(
+                      "source=%s  |  eval a=SECOND('2025-12-01 15:02:61') | fields a",
+                      TEST_INDEX_DATE_FORMATS_WITH_NULL));
+        });
+  }
+
+  @Test
+  public void testSECOND_OF_MINUTEInvalid() {
+
+    assertThrows(
+        Exception.class,
+        () -> {
+          JSONObject actual =
+              executeQuery(
+                  String.format(
+                      "source=%s  |  eval a=SECOND_OF_MINUTE('2025-13-02') | fields a",
+                      TEST_INDEX_DATE_FORMATS_WITH_NULL));
+        });
+
+    assertThrows(
+        Exception.class,
+        () -> {
+          JSONObject actual =
+              executeQuery(
+                  String.format(
+                      "source=%s  |  eval a=SECOND_OF_MINUTE('16:00:61') | fields a",
+                      TEST_INDEX_DATE_FORMATS_WITH_NULL));
+        });
+
+    assertThrows(
+        Exception.class,
+        () -> {
+          JSONObject actual =
+              executeQuery(
+                  String.format(
+                      "source=%s  |  eval a=SECOND_OF_MINUTE('2025-12-01 15:02:61') | fields a",
+                      TEST_INDEX_DATE_FORMATS_WITH_NULL));
+        });
+  }
+
+  @Test
+  public void testTIME_TO_SECInvalid() {
+
+    assertThrows(
+        Exception.class,
+        () -> {
+          JSONObject actual =
+              executeQuery(
+                  String.format(
+                      "source=%s  |  eval a=TIME_TO_SEC('2025-13-02') | fields a",
+                      TEST_INDEX_DATE_FORMATS_WITH_NULL));
+        });
+
+    assertThrows(
+        Exception.class,
+        () -> {
+          JSONObject actual =
+              executeQuery(
+                  String.format(
+                      "source=%s  |  eval a=TIME_TO_SEC('16:00:61') | fields a",
+                      TEST_INDEX_DATE_FORMATS_WITH_NULL));
+        });
+
+    assertThrows(
+        Exception.class,
+        () -> {
+          JSONObject actual =
+              executeQuery(
+                  String.format(
+                      "source=%s  |  eval a=TIME_TO_SEC('2025-12-01 15:02:61') | fields a",
+                      TEST_INDEX_DATE_FORMATS_WITH_NULL));
+        });
+  }
+
+  @Test
+  public void testTIMESTAMPInvalid() {
+
+    assertThrows(
+        Exception.class,
+        () -> {
+          JSONObject actual =
+              executeQuery(
+                  String.format(
+                      "source=%s  |  eval a=TIMESTAMP('2025-13-02') | fields a",
+                      TEST_INDEX_DATE_FORMATS_WITH_NULL));
+        });
+
+    assertThrows(
+        Exception.class,
+        () -> {
+          JSONObject actual =
+              executeQuery(
+                  String.format(
+                      "source=%s  |  eval a=TIMESTAMP('16:00:61') | fields a",
+                      TEST_INDEX_DATE_FORMATS_WITH_NULL));
+        });
+
+    assertThrows(
+        Exception.class,
+        () -> {
+          JSONObject actual =
+              executeQuery(
+                  String.format(
+                      "source=%s  |  eval a=TIMESTAMP('2025-12-01 15:02:61') | fields a",
+                      TEST_INDEX_DATE_FORMATS_WITH_NULL));
+        });
+
+    assertThrows(
+        Exception.class,
+        () -> {
+          JSONObject actual =
+              executeQuery(
+                  String.format(
+                      "source=%s  |  eval a=TIMESTAMP('2025-13-02') | fields a",
+                      TEST_INDEX_DATE_FORMATS_WITH_NULL));
+        });
+
+    assertThrows(
+        Exception.class,
+        () -> {
+          JSONObject actual =
+              executeQuery(
+                  String.format(
+                      "source=%s  |  eval a=TIMESTAMP('16:00:61') | fields a",
+                      TEST_INDEX_DATE_FORMATS_WITH_NULL));
+        });
+
+    assertThrows(
+        Exception.class,
+        () -> {
+          JSONObject actual =
+              executeQuery(
+                  String.format(
+                      "source=%s  |  eval a=TIMESTAMP('2025-12-01 15:02:61') | fields a",
+                      TEST_INDEX_DATE_FORMATS_WITH_NULL));
+        });
+
+    assertThrows(
+        Exception.class,
+        () -> {
+          JSONObject actual =
+              executeQuery(
+                  String.format(
+                      "source=%s  |  eval a=TIMESTAMP('2025-13-02', '2025-13-02') | fields a",
+                      TEST_INDEX_DATE_FORMATS_WITH_NULL));
+        });
+
+    assertThrows(
+        Exception.class,
+        () -> {
+          JSONObject actual =
+              executeQuery(
+                  String.format(
+                      "source=%s  |  eval a=TIMESTAMP('16:00:61', '16:00:61') | fields a",
+                      TEST_INDEX_DATE_FORMATS_WITH_NULL));
+        });
+
+    assertThrows(
+        Exception.class,
+        () -> {
+          JSONObject actual =
+              executeQuery(
+                  String.format(
+                      "source=%s  |  eval a=TIMESTAMP('2025-12-01 15:02:61', '2025-12-01 15:02:61')"
+                          + " | fields a",
+                      TEST_INDEX_DATE_FORMATS_WITH_NULL));
+        });
+  }
+
+  @Test
+  public void testTO_DAYSInvalid() {
+
+    assertThrows(
+        Exception.class,
+        () -> {
+          JSONObject actual =
+              executeQuery(
+                  String.format(
+                      "source=%s  |  eval a=TO_DAYS('2025-13-02') | fields a",
+                      TEST_INDEX_DATE_FORMATS_WITH_NULL));
+        });
+
+    assertThrows(
+        Exception.class,
+        () -> {
+          JSONObject actual =
+              executeQuery(
+                  String.format(
+                      "source=%s  |  eval a=TO_DAYS('16:00:61') | fields a",
+                      TEST_INDEX_DATE_FORMATS_WITH_NULL));
+        });
+
+    assertThrows(
+        Exception.class,
+        () -> {
+          JSONObject actual =
+              executeQuery(
+                  String.format(
+                      "source=%s  |  eval a=TO_DAYS('2025-12-01 15:02:61') | fields a",
+                      TEST_INDEX_DATE_FORMATS_WITH_NULL));
+        });
+  }
+
+  @Test
+  public void testYEARInvalid() {
+
+    assertThrows(
+        Exception.class,
+        () -> {
+          JSONObject actual =
+              executeQuery(
+                  String.format(
+                      "source=%s  |  eval a=YEAR('2025-13-02') | fields a",
+                      TEST_INDEX_DATE_FORMATS_WITH_NULL));
+        });
+
+    assertThrows(
+        Exception.class,
+        () -> {
+          JSONObject actual =
+              executeQuery(
+                  String.format(
+                      "source=%s  |  eval a=YEAR('16:00:61') | fields a",
+                      TEST_INDEX_DATE_FORMATS_WITH_NULL));
+        });
+
+    assertThrows(
+        Exception.class,
+        () -> {
+          JSONObject actual =
+              executeQuery(
+                  String.format(
+                      "source=%s  |  eval a=YEAR('2025-12-01 15:02:61') | fields a",
+                      TEST_INDEX_DATE_FORMATS_WITH_NULL));
+        });
+  }
+
+  @Test
+  public void testWEEKInvalid() {
+
+    assertThrows(
+        Exception.class,
+        () -> {
+          JSONObject actual =
+              executeQuery(
+                  String.format(
+                      "source=%s  |  eval a=WEEK('2025-13-02') | fields a",
+                      TEST_INDEX_DATE_FORMATS_WITH_NULL));
+        });
+
+    assertThrows(
+        Exception.class,
+        () -> {
+          JSONObject actual =
+              executeQuery(
+                  String.format(
+                      "source=%s  |  eval a=WEEK('16:00:61') | fields a",
+                      TEST_INDEX_DATE_FORMATS_WITH_NULL));
+        });
+
+    assertThrows(
+        Exception.class,
+        () -> {
+          JSONObject actual =
+              executeQuery(
+                  String.format(
+                      "source=%s  |  eval a=WEEK('2025-12-01 15:02:61') | fields a",
+                      TEST_INDEX_DATE_FORMATS_WITH_NULL));
+        });
+  }
+
+  @Test
+  public void testWEEK_OF_YEARInvalid() {
+
+    assertThrows(
+        Exception.class,
+        () -> {
+          JSONObject actual =
+              executeQuery(
+                  String.format(
+                      "source=%s  |  eval a=WEEK_OF_YEAR('2025-13-02') | fields a",
+                      TEST_INDEX_DATE_FORMATS_WITH_NULL));
+        });
+
+    assertThrows(
+        Exception.class,
+        () -> {
+          JSONObject actual =
+              executeQuery(
+                  String.format(
+                      "source=%s  |  eval a=WEEK_OF_YEAR('16:00:61') | fields a",
+                      TEST_INDEX_DATE_FORMATS_WITH_NULL));
+        });
+
+    assertThrows(
+        Exception.class,
+        () -> {
+          JSONObject actual =
+              executeQuery(
+                  String.format(
+                      "source=%s  |  eval a=WEEK_OF_YEAR('2025-12-01 15:02:61') | fields a",
+                      TEST_INDEX_DATE_FORMATS_WITH_NULL));
+        });
+  }
+
+  @Test
+  public void testWEEKDAYInvalid() {
+
+    assertThrows(
+        Exception.class,
+        () -> {
+          JSONObject actual =
+              executeQuery(
+                  String.format(
+                      "source=%s  |  eval a=WEEKDAY('2025-13-02') | fields a",
+                      TEST_INDEX_DATE_FORMATS_WITH_NULL));
+        });
+
+    assertThrows(
+        Exception.class,
+        () -> {
+          JSONObject actual =
+              executeQuery(
+                  String.format(
+                      "source=%s  |  eval a=WEEKDAY('16:00:61') | fields a",
+                      TEST_INDEX_DATE_FORMATS_WITH_NULL));
+        });
+
+    assertThrows(
+        Exception.class,
+        () -> {
+          JSONObject actual =
+              executeQuery(
+                  String.format(
+                      "source=%s  |  eval a=WEEKDAY('2025-12-01 15:02:61') | fields a",
+                      TEST_INDEX_DATE_FORMATS_WITH_NULL));
+        });
+  }
+
+  @Test
+  public void testYEARWEEKInvalid() {
+
+    assertThrows(
+        Exception.class,
+        () -> {
+          JSONObject actual =
+              executeQuery(
+                  String.format(
+                      "source=%s  |  eval a=YEARWEEK('2025-13-02') | fields a",
+                      TEST_INDEX_DATE_FORMATS_WITH_NULL));
+        });
+
+    assertThrows(
+        Exception.class,
+        () -> {
+          JSONObject actual =
+              executeQuery(
+                  String.format(
+                      "source=%s  |  eval a=YEARWEEK('16:00:61') | fields a",
+                      TEST_INDEX_DATE_FORMATS_WITH_NULL));
+        });
+
+    assertThrows(
+        Exception.class,
+        () -> {
+          JSONObject actual =
+              executeQuery(
+                  String.format(
+                      "source=%s  |  eval a=YEARWEEK('2025-12-01 15:02:61') | fields a",
+                      TEST_INDEX_DATE_FORMATS_WITH_NULL));
+        });
+  }
+
+  @Test
+  public void testADDTATEInvalid() {
+
+    assertThrows(
+        Exception.class,
+        () -> {
+          JSONObject actual =
+              executeQuery(
+                  String.format(
+                      "source=%s  |  eval a=ADDTATE('2025-13-02', INTERVAL 1 HOUR) | fields a",
+                      TEST_INDEX_DATE_FORMATS_WITH_NULL));
+        });
+
+    assertThrows(
+        Exception.class,
+        () -> {
+          JSONObject actual =
+              executeQuery(
+                  String.format(
+                      "source=%s  |  eval a=ADDTATE('16:00:61', INTERVAL 1 HOUR) | fields a",
+                      TEST_INDEX_DATE_FORMATS_WITH_NULL));
+        });
+
+    assertThrows(
+        Exception.class,
+        () -> {
+          JSONObject actual =
+              executeQuery(
+                  String.format(
+                      "source=%s  |  eval a=ADDTATE('2025-12-01 15:02:61', INTERVAL 1 HOUR) |"
+                          + " fields a",
+                      TEST_INDEX_DATE_FORMATS_WITH_NULL));
+        });
+
+    assertThrows(
+        Exception.class,
+        () -> {
+          JSONObject actual =
+              executeQuery(
+                  String.format(
+                      "source=%s  |  eval a=ADDTATE('2025-13-02', 1) | fields a",
+                      TEST_INDEX_DATE_FORMATS_WITH_NULL));
+        });
+
+    assertThrows(
+        Exception.class,
+        () -> {
+          JSONObject actual =
+              executeQuery(
+                  String.format(
+                      "source=%s  |  eval a=ADDTATE('16:00:61', 1) | fields a",
+                      TEST_INDEX_DATE_FORMATS_WITH_NULL));
+        });
+
+    assertThrows(
+        Exception.class,
+        () -> {
+          JSONObject actual =
+              executeQuery(
+                  String.format(
+                      "source=%s  |  eval a=ADDTATE('2025-12-01 15:02:61', 1) | fields a",
+                      TEST_INDEX_DATE_FORMATS_WITH_NULL));
+        });
+  }
+
+  @Test
+  public void testADDTIMEInvalid() {
+
+    assertThrows(
+        Exception.class,
+        () -> {
+          JSONObject actual =
+              executeQuery(
+                  String.format(
+                      "source=%s  |  eval a=ADDTIME('2025-13-02', '2025-13-02') | fields a",
+                      TEST_INDEX_DATE_FORMATS_WITH_NULL));
+        });
+
+    assertThrows(
+        Exception.class,
+        () -> {
+          JSONObject actual =
+              executeQuery(
+                  String.format(
+                      "source=%s  |  eval a=ADDTIME('16:00:61', '16:00:61') | fields a",
+                      TEST_INDEX_DATE_FORMATS_WITH_NULL));
+        });
+
+    assertThrows(
+        Exception.class,
+        () -> {
+          JSONObject actual =
+              executeQuery(
+                  String.format(
+                      "source=%s  |  eval a=ADDTIME('2025-12-01 15:02:61', '2025-12-01 15:02:61') |"
+                          + " fields a",
+                      TEST_INDEX_DATE_FORMATS_WITH_NULL));
+        });
+  }
+
+  @Test
+  public void testDATE_ADDInvalid() {
+
+    assertThrows(
+        Exception.class,
+        () -> {
+          JSONObject actual =
+              executeQuery(
+                  String.format(
+                      "source=%s  |  eval a=DATE_ADD('2025-13-02', INTERVAL 1 HOUR) | fields a",
+                      TEST_INDEX_DATE_FORMATS_WITH_NULL));
+        });
+
+    assertThrows(
+        Exception.class,
+        () -> {
+          JSONObject actual =
+              executeQuery(
+                  String.format(
+                      "source=%s  |  eval a=DATE_ADD('16:00:61', INTERVAL 1 HOUR) | fields a",
+                      TEST_INDEX_DATE_FORMATS_WITH_NULL));
+        });
+
+    assertThrows(
+        Exception.class,
+        () -> {
+          JSONObject actual =
+              executeQuery(
+                  String.format(
+                      "source=%s  |  eval a=DATE_ADD('2025-12-01 15:02:61', INTERVAL 1 HOUR) |"
+                          + " fields a",
+                      TEST_INDEX_DATE_FORMATS_WITH_NULL));
+        });
+  }
+
+  @Test
+  public void testDATE_SUBInvalid() {
+
+    assertThrows(
+        Exception.class,
+        () -> {
+          JSONObject actual =
+              executeQuery(
+                  String.format(
+                      "source=%s  |  eval a=DATE_SUB('2025-13-02', INTERVAL 1 HOUR) | fields a",
+                      TEST_INDEX_DATE_FORMATS_WITH_NULL));
+        });
+
+    assertThrows(
+        Exception.class,
+        () -> {
+          JSONObject actual =
+              executeQuery(
+                  String.format(
+                      "source=%s  |  eval a=DATE_SUB('16:00:61', INTERVAL 1 HOUR) | fields a",
+                      TEST_INDEX_DATE_FORMATS_WITH_NULL));
+        });
+
+    assertThrows(
+        Exception.class,
+        () -> {
+          JSONObject actual =
+              executeQuery(
+                  String.format(
+                      "source=%s  |  eval a=DATE_SUB('2025-12-01 15:02:61', INTERVAL 1 HOUR) |"
+                          + " fields a",
+                      TEST_INDEX_DATE_FORMATS_WITH_NULL));
+        });
+  }
+
+  @Test
+  public void testDATEDIFFInvalid() {
+
+    assertThrows(
+        Exception.class,
+        () -> {
+          JSONObject actual =
+              executeQuery(
+                  String.format(
+                      "source=%s  |  eval a=DATEDIFF('2025-13-02', '2025-13-02') | fields a",
+                      TEST_INDEX_DATE_FORMATS_WITH_NULL));
+        });
+
+    assertThrows(
+        Exception.class,
+        () -> {
+          JSONObject actual =
+              executeQuery(
+                  String.format(
+                      "source=%s  |  eval a=DATEDIFF('16:00:61', '16:00:61') | fields a",
+                      TEST_INDEX_DATE_FORMATS_WITH_NULL));
+        });
+
+    assertThrows(
+        Exception.class,
+        () -> {
+          JSONObject actual =
+              executeQuery(
+                  String.format(
+                      "source=%s  |  eval a=DATEDIFF('2025-12-01 15:02:61', '2025-12-01 15:02:61')"
+                          + " | fields a",
+                      TEST_INDEX_DATE_FORMATS_WITH_NULL));
+        });
+  }
+
+  @Test
+  public void testSUBDATEInvalid() {
+
+    assertThrows(
+        Exception.class,
+        () -> {
+          JSONObject actual =
+              executeQuery(
+                  String.format(
+                      "source=%s  |  eval a=SUBDATE('2025-13-02', INTERVAL 1 HOUR) | fields a",
+                      TEST_INDEX_DATE_FORMATS_WITH_NULL));
+        });
+
+    assertThrows(
+        Exception.class,
+        () -> {
+          JSONObject actual =
+              executeQuery(
+                  String.format(
+                      "source=%s  |  eval a=SUBDATE('16:00:61', INTERVAL 1 HOUR) | fields a",
+                      TEST_INDEX_DATE_FORMATS_WITH_NULL));
+        });
+
+    assertThrows(
+        Exception.class,
+        () -> {
+          JSONObject actual =
+              executeQuery(
+                  String.format(
+                      "source=%s  |  eval a=SUBDATE('2025-12-01 15:02:61', INTERVAL 1 HOUR) |"
+                          + " fields a",
+                      TEST_INDEX_DATE_FORMATS_WITH_NULL));
+        });
+
+    assertThrows(
+        Exception.class,
+        () -> {
+          JSONObject actual =
+              executeQuery(
+                  String.format(
+                      "source=%s  |  eval a=SUBDATE('2025-13-02', 1) | fields a",
+                      TEST_INDEX_DATE_FORMATS_WITH_NULL));
+        });
+
+    assertThrows(
+        Exception.class,
+        () -> {
+          JSONObject actual =
+              executeQuery(
+                  String.format(
+                      "source=%s  |  eval a=SUBDATE('16:00:61', 1) | fields a",
+                      TEST_INDEX_DATE_FORMATS_WITH_NULL));
+        });
+
+    assertThrows(
+        Exception.class,
+        () -> {
+          JSONObject actual =
+              executeQuery(
+                  String.format(
+                      "source=%s  |  eval a=SUBDATE('2025-12-01 15:02:61', 1) | fields a",
+                      TEST_INDEX_DATE_FORMATS_WITH_NULL));
+        });
+  }
+
+  @Test
+  public void testSUBTIMEInvalid() {
+
+    assertThrows(
+        Exception.class,
+        () -> {
+          JSONObject actual =
+              executeQuery(
+                  String.format(
+                      "source=%s  |  eval a=SUBTIME('2025-13-02', '2025-13-02') | fields a",
+                      TEST_INDEX_DATE_FORMATS_WITH_NULL));
+        });
+
+    assertThrows(
+        Exception.class,
+        () -> {
+          JSONObject actual =
+              executeQuery(
+                  String.format(
+                      "source=%s  |  eval a=SUBTIME('16:00:61', '16:00:61') | fields a",
+                      TEST_INDEX_DATE_FORMATS_WITH_NULL));
+        });
+
+    assertThrows(
+        Exception.class,
+        () -> {
+          JSONObject actual =
+              executeQuery(
+                  String.format(
+                      "source=%s  |  eval a=SUBTIME('2025-12-01 15:02:61', '2025-12-01 15:02:61') |"
+                          + " fields a",
+                      TEST_INDEX_DATE_FORMATS_WITH_NULL));
+        });
+  }
+
+  @Test
+  public void testTIMESTAMPADDInvalid() {
+
+    assertThrows(
+        Exception.class,
+        () -> {
+          JSONObject actual =
+              executeQuery(
+                  String.format(
+                      "source=%s  |  eval a=TIMESTAMPADD(INTERVAL 1 HOUR, 1, '2025-13-02') | fields"
+                          + " a",
+                      TEST_INDEX_DATE_FORMATS_WITH_NULL));
+        });
+
+    assertThrows(
+        Exception.class,
+        () -> {
+          JSONObject actual =
+              executeQuery(
+                  String.format(
+                      "source=%s  |  eval a=TIMESTAMPADD(INTERVAL 1 HOUR, 1, '16:00:61') | fields"
+                          + " a",
+                      TEST_INDEX_DATE_FORMATS_WITH_NULL));
+        });
+
+    assertThrows(
+        Exception.class,
+        () -> {
+          JSONObject actual =
+              executeQuery(
+                  String.format(
+                      "source=%s  |  eval a=TIMESTAMPADD(INTERVAL 1 HOUR, 1, '2025-12-01 15:02:61')"
+                          + " | fields a",
+                      TEST_INDEX_DATE_FORMATS_WITH_NULL));
+        });
+  }
+
+  @Test
+  public void testTIMESTAMPDIFFInvalid() {
+
+    assertThrows(
+        Exception.class,
+        () -> {
+          JSONObject actual =
+              executeQuery(
+                  String.format(
+                      "source=%s  |  eval a=TIMESTAMPDIFF(INTERVAL 1 HOUR, '2025-13-02',"
+                          + " '2025-13-02') | fields a",
+                      TEST_INDEX_DATE_FORMATS_WITH_NULL));
+        });
+
+    assertThrows(
+        Exception.class,
+        () -> {
+          JSONObject actual =
+              executeQuery(
+                  String.format(
+                      "source=%s  |  eval a=TIMESTAMPDIFF(INTERVAL 1 HOUR, '16:00:61', '16:00:61')"
+                          + " | fields a",
+                      TEST_INDEX_DATE_FORMATS_WITH_NULL));
+        });
+
+    assertThrows(
+        Exception.class,
+        () -> {
+          JSONObject actual =
+              executeQuery(
+                  String.format(
+                      "source=%s  |  eval a=TIMESTAMPDIFF(INTERVAL 1 HOUR, '2025-12-01 15:02:61',"
+                          + " '2025-12-01 15:02:61') | fields a",
+                      TEST_INDEX_DATE_FORMATS_WITH_NULL));
+        });
+  }
+
+  @Test
+  public void testDATE_FORMATInvalid() {
+
+    assertThrows(
+        Exception.class,
+        () -> {
+          JSONObject actual =
+              executeQuery(
+                  String.format(
+                      "source=%s  |  eval a=DATE_FORMAT('2025-13-02', '2025-13-02') | fields a",
+                      TEST_INDEX_DATE_FORMATS_WITH_NULL));
+        });
+
+    assertThrows(
+        Exception.class,
+        () -> {
+          JSONObject actual =
+              executeQuery(
+                  String.format(
+                      "source=%s  |  eval a=DATE_FORMAT('16:00:61', '16:00:61') | fields a",
+                      TEST_INDEX_DATE_FORMATS_WITH_NULL));
+        });
+
+    assertThrows(
+        Exception.class,
+        () -> {
+          JSONObject actual =
+              executeQuery(
+                  String.format(
+                      "source=%s  |  eval a=DATE_FORMAT('2025-12-01 15:02:61', '2025-12-01"
+                          + " 15:02:61') | fields a",
+                      TEST_INDEX_DATE_FORMATS_WITH_NULL));
+        });
+  }
+
+  @Test
+  public void testTIME_FORMATInvalid() {
+
+    assertThrows(
+        Exception.class,
+        () -> {
+          JSONObject actual =
+              executeQuery(
+                  String.format(
+                      "source=%s  |  eval a=TIME_FORMAT('2025-13-02', '2025-13-02') | fields a",
+                      TEST_INDEX_DATE_FORMATS_WITH_NULL));
+        });
+
+    assertThrows(
+        Exception.class,
+        () -> {
+          JSONObject actual =
+              executeQuery(
+                  String.format(
+                      "source=%s  |  eval a=TIME_FORMAT('16:00:61', '16:00:61') | fields a",
+                      TEST_INDEX_DATE_FORMATS_WITH_NULL));
+        });
+
+    assertThrows(
+        Exception.class,
+        () -> {
+          JSONObject actual =
+              executeQuery(
+                  String.format(
+                      "source=%s  |  eval a=TIME_FORMAT('2025-12-01 15:02:61', '2025-12-01"
+                          + " 15:02:61') | fields a",
+                      TEST_INDEX_DATE_FORMATS_WITH_NULL));
+        });
+  }
 }

--- a/integ-test/src/test/java/org/opensearch/sql/calcite/remote/fallback/CalciteLikeQueryIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/calcite/remote/fallback/CalciteLikeQueryIT.java
@@ -5,11 +5,10 @@
 
 package org.opensearch.sql.calcite.remote.fallback;
 
+import java.io.IOException;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.opensearch.sql.ppl.LikeQueryIT;
-
-import java.io.IOException;
 
 // TODO Like function behaviour in V2 is not correct. Remove when it was fixed in V2.
 @Ignore("https://github.com/opensearch-project/sql/issues/3428")

--- a/integ-test/src/test/java/org/opensearch/sql/calcite/remote/nonfallback/NonFallbackCalciteConvertTZFunctionIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/calcite/remote/nonfallback/NonFallbackCalciteConvertTZFunctionIT.java
@@ -5,10 +5,9 @@
 
 package org.opensearch.sql.calcite.remote.nonfallback;
 
-import org.junit.Ignore;
 import org.opensearch.sql.calcite.remote.fallback.CalciteConvertTZFunctionIT;
 
-//@Ignore("https://github.com/opensearch-project/sql/issues/3400")
+// @Ignore("https://github.com/opensearch-project/sql/issues/3400")
 public class NonFallbackCalciteConvertTZFunctionIT extends CalciteConvertTZFunctionIT {
   @Override
   public void init() throws Exception {

--- a/integ-test/src/test/java/org/opensearch/sql/calcite/remote/nonfallback/NonFallbackCalciteDateTimeFunctionIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/calcite/remote/nonfallback/NonFallbackCalciteDateTimeFunctionIT.java
@@ -5,12 +5,11 @@
 
 package org.opensearch.sql.calcite.remote.nonfallback;
 
+import java.io.IOException;
 import org.junit.Ignore;
 import org.opensearch.sql.calcite.remote.fallback.CalciteDateTimeFunctionIT;
 
-import java.io.IOException;
-
-//@Ignore("https://github.com/opensearch-project/sql/issues/3400")
+// @Ignore("https://github.com/opensearch-project/sql/issues/3400")
 public class NonFallbackCalciteDateTimeFunctionIT extends CalciteDateTimeFunctionIT {
   @Override
   public void init() throws Exception {

--- a/integ-test/src/test/java/org/opensearch/sql/calcite/remote/nonfallback/NonFallbackCalciteDateTimeImplementationIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/calcite/remote/nonfallback/NonFallbackCalciteDateTimeImplementationIT.java
@@ -5,10 +5,9 @@
 
 package org.opensearch.sql.calcite.remote.nonfallback;
 
-import org.junit.Ignore;
 import org.opensearch.sql.calcite.remote.fallback.CalciteDateTimeImplementationIT;
 
-//@Ignore("https://github.com/opensearch-project/sql/issues/3400")
+// @Ignore("https://github.com/opensearch-project/sql/issues/3400")
 public class NonFallbackCalciteDateTimeImplementationIT extends CalciteDateTimeImplementationIT {
   @Override
   public void init() throws Exception {

--- a/integ-test/src/test/java/org/opensearch/sql/calcite/remote/nonfallback/NonFallbackCalciteNowLikeFunctionIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/calcite/remote/nonfallback/NonFallbackCalciteNowLikeFunctionIT.java
@@ -5,24 +5,13 @@
 
 package org.opensearch.sql.calcite.remote.nonfallback;
 
-import java.io.IOException;
-import java.time.LocalDate;
-import java.time.LocalDateTime;
-import java.time.LocalTime;
 import java.time.format.DateTimeFormatter;
 import java.time.temporal.Temporal;
-import java.util.Arrays;
 import java.util.function.BiFunction;
 import java.util.function.Supplier;
-
-import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
 import org.opensearch.sql.calcite.remote.fallback.CalciteNowLikeFunctionIT;
 
-import static com.carrotsearch.randomizedtesting.RandomizedTest.$;
-import static com.carrotsearch.randomizedtesting.RandomizedTest.$$;
-import static org.opensearch.sql.sql.NowLikeFunctionIT.utcDateTimeNow;
-
-//@Ignore("https://github.com/opensearch-project/sql/issues/3400")
+// @Ignore("https://github.com/opensearch-project/sql/issues/3400")
 public class NonFallbackCalciteNowLikeFunctionIT extends CalciteNowLikeFunctionIT {
   public NonFallbackCalciteNowLikeFunctionIT(
       String name,

--- a/integ-test/src/test/java/org/opensearch/sql/calcite/remote/nonfallback/NonFallbackCalciteStatsCommandIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/calcite/remote/nonfallback/NonFallbackCalciteStatsCommandIT.java
@@ -19,25 +19,25 @@ public class NonFallbackCalciteStatsCommandIT extends CalciteStatsCommandIT {
     disallowCalciteFallback();
   }
 
-  //@Ignore("Percentile is unsupported in Calcite now")
+  // @Ignore("Percentile is unsupported in Calcite now")
   @Override
   public void testStatsPercentile() throws IOException {
     super.testStatsPercentile();
   }
 
-  //@Ignore("Percentile is unsupported in Calcite now")
+  // @Ignore("Percentile is unsupported in Calcite now")
   @Override
   public void testStatsPercentileWithNull() throws IOException {
     super.testStatsPercentileWithNull();
   }
 
-  //@Ignore("Percentile is unsupported in Calcite now")
+  // @Ignore("Percentile is unsupported in Calcite now")
   @Override
   public void testStatsPercentileWithCompression() throws IOException {
     super.testStatsPercentileWithCompression();
   }
 
-  //@Ignore("Percentile is unsupported in Calcite now")
+  // @Ignore("Percentile is unsupported in Calcite now")
   @Override
   public void testStatsPercentileWhere() throws IOException {
     super.testStatsPercentileWhere();
@@ -49,7 +49,7 @@ public class NonFallbackCalciteStatsCommandIT extends CalciteStatsCommandIT {
     super.testStatsPercentileByNullValue();
   }
 
-  //@Ignore("Percentile is unsupported in Calcite now")
+  // @Ignore("Percentile is unsupported in Calcite now")
   @Override
   public void testStatsPercentileBySpan() throws IOException {
     super.testStatsPercentileBySpan();

--- a/integ-test/src/test/java/org/opensearch/sql/calcite/standalone/CalciteBuiltinFunctionsNullIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/calcite/standalone/CalciteBuiltinFunctionsNullIT.java
@@ -1,1003 +1,1020 @@
 package org.opensearch.sql.calcite.standalone;
 
-import org.json.JSONArray;
-import org.json.JSONObject;
-import org.junit.Ignore;
-import org.junit.jupiter.api.Test;
-import org.opensearch.sql.exception.SemanticCheckException;
-
-import java.io.IOException;
-
 import static org.opensearch.sql.legacy.TestsConstants.TEST_INDEX_DATE_FORMATS_WITH_NULL;
 import static org.opensearch.sql.legacy.TestsConstants.TEST_INDEX_NULL_MISSING;
 import static org.opensearch.sql.legacy.TestsConstants.TEST_INDEX_STATE_COUNTRY_WITH_NULL;
 import static org.opensearch.sql.util.MatcherUtils.*;
 import static org.opensearch.sql.util.MatcherUtils.rows;
 
+import java.io.IOException;
+import org.json.JSONArray;
+import org.json.JSONObject;
+import org.junit.Ignore;
+import org.junit.jupiter.api.Test;
+import org.opensearch.sql.exception.SemanticCheckException;
+
 public class CalciteBuiltinFunctionsNullIT extends CalcitePPLIntegTestCase {
-    @Override
-    public void init() throws IOException {
-        super.init();
-        loadIndex(Index.STATE_COUNTRY);
-        loadIndex(Index.STATE_COUNTRY_WITH_NULL);
-        loadIndex(Index.DATE_FORMATS);
-        loadIndex(Index.DATE_FORMATS_WITH_NULL);
-        loadIndex(Index.NULL_MISSING);
-    }
+  @Override
+  public void init() throws IOException {
+    super.init();
+    loadIndex(Index.STATE_COUNTRY);
+    loadIndex(Index.STATE_COUNTRY_WITH_NULL);
+    loadIndex(Index.DATE_FORMATS);
+    loadIndex(Index.DATE_FORMATS_WITH_NULL);
+    loadIndex(Index.NULL_MISSING);
+  }
 
-    @Test
-    public void testYearWeekInvalid() {
-        assertThrows(Exception.class, () -> {
-            // Code that should throw the exception
-            JSONObject actual =
-                    executeQuery(
-                            String.format(
-                                    "source=%s  | eval `YEARWEEK('2020-08-26')` = YEARWEEK('2020-15-26')",
-                                    TEST_INDEX_DATE_FORMATS_WITH_NULL));
+  @Test
+  public void testYearWeekInvalid() {
+    assertThrows(
+        Exception.class,
+        () -> {
+          // Code that should throw the exception
+          JSONObject actual =
+              executeQuery(
+                  String.format(
+                      "source=%s  | eval `YEARWEEK('2020-08-26')` = YEARWEEK('2020-15-26')",
+                      TEST_INDEX_DATE_FORMATS_WITH_NULL));
         });
+  }
+
+  @Test
+  public void testYearWeekNull() {
+    JSONObject actual =
+        executeQuery(
+            String.format(
+                "source=%s  |  eval NullValue = YEARWEEK(date) | fields NullValue",
+                TEST_INDEX_DATE_FORMATS_WITH_NULL));
+
+    verifySchema(actual, schema("NullValue", "integer"));
+    JSONArray ret = actual.getJSONArray("datarows");
+    for (int i = 0; i < ret.length(); i++) {
+      Object o = ((JSONArray) ret.get(i)).get(0);
+      assertEquals(JSONObject.NULL, o);
     }
+  }
 
-    @Test
-    public void testYearWeekNull() {
-        JSONObject actual =
-                executeQuery(
-                        String.format(
-                                "source=%s  |  eval NullValue = YEARWEEK(date) | fields NullValue",
-                                TEST_INDEX_DATE_FORMATS_WITH_NULL));
-
-
-        verifySchema(
-                actual,
-                schema("NullValue", "integer"));
-        JSONArray ret = actual.getJSONArray("datarows");
-        for (int i = 0; i < ret.length(); i++) {
-            Object o = ((JSONArray) ret.get(i)).get(0);
-            assertEquals(JSONObject.NULL, o);
-        }
-    }
-
-    @Test
-    public void testYearInvalid() {
-        assertThrows(Exception.class, () -> {
-            // Code that should throw the exception
-            JSONObject actual =
-                    executeQuery(
-                            String.format(
-                                    "source=%s  | eval a = YEAR('2020-15-26')",
-                                    TEST_INDEX_DATE_FORMATS_WITH_NULL));
+  @Test
+  public void testYearInvalid() {
+    assertThrows(
+        Exception.class,
+        () -> {
+          // Code that should throw the exception
+          JSONObject actual =
+              executeQuery(
+                  String.format(
+                      "source=%s  | eval a = YEAR('2020-15-26')",
+                      TEST_INDEX_DATE_FORMATS_WITH_NULL));
         });
-        assertThrows(Exception.class, () -> {
-            // Code that should throw the exception
-            JSONObject actual =
-                    executeQuery(
-                            String.format(
-                                    "source=%s  | eval a = YEAR('2020-12-26 25:00:00')",
-                                    TEST_INDEX_DATE_FORMATS_WITH_NULL));
+    assertThrows(
+        Exception.class,
+        () -> {
+          // Code that should throw the exception
+          JSONObject actual =
+              executeQuery(
+                  String.format(
+                      "source=%s  | eval a = YEAR('2020-12-26 25:00:00')",
+                      TEST_INDEX_DATE_FORMATS_WITH_NULL));
         });
-    }
+  }
 
-
-    @Test
-    public void testWeekInvalid() {
-        assertThrows(Exception.class, () -> {
-            // Code that should throw the exception
-            JSONObject actual =
-                    executeQuery(
-                            String.format(
-                                    "source=%s  | eval a = WEEK('2020-15-26')",
-                                    TEST_INDEX_DATE_FORMATS_WITH_NULL));
+  @Test
+  public void testWeekInvalid() {
+    assertThrows(
+        Exception.class,
+        () -> {
+          // Code that should throw the exception
+          JSONObject actual =
+              executeQuery(
+                  String.format(
+                      "source=%s  | eval a = WEEK('2020-15-26')",
+                      TEST_INDEX_DATE_FORMATS_WITH_NULL));
         });
-        assertThrows(Exception.class, () -> {
-            // Code that should throw the exception
-            JSONObject actual =
-                    executeQuery(
-                            String.format(
-                                    "source=%s  | eval a = WEEK('2020-12-26 25:00:00')",
-                                    TEST_INDEX_DATE_FORMATS_WITH_NULL));
+    assertThrows(
+        Exception.class,
+        () -> {
+          // Code that should throw the exception
+          JSONObject actual =
+              executeQuery(
+                  String.format(
+                      "source=%s  | eval a = WEEK('2020-12-26 25:00:00')",
+                      TEST_INDEX_DATE_FORMATS_WITH_NULL));
         });
-    }
+  }
 
-    @Test
-    public void testWeekDayInvalid() {
-        assertThrows(Exception.class, () -> {
-            // Code that should throw the exception
-            JSONObject actual =
-                    executeQuery(
-                            String.format(
-                                    "source=%s  | eval a = WEEKDAY('2020-15-26')",
-                                    TEST_INDEX_DATE_FORMATS_WITH_NULL));
+  @Test
+  public void testWeekDayInvalid() {
+    assertThrows(
+        Exception.class,
+        () -> {
+          // Code that should throw the exception
+          JSONObject actual =
+              executeQuery(
+                  String.format(
+                      "source=%s  | eval a = WEEKDAY('2020-15-26')",
+                      TEST_INDEX_DATE_FORMATS_WITH_NULL));
         });
-        assertThrows(Exception.class, () -> {
-            // Code that should throw the exception
-            JSONObject actual =
-                    executeQuery(
-                            String.format(
-                                    "source=%s  | eval a = WEEKDAY('2020-12-26 25:00:00')",
-                                    TEST_INDEX_DATE_FORMATS_WITH_NULL));
+    assertThrows(
+        Exception.class,
+        () -> {
+          // Code that should throw the exception
+          JSONObject actual =
+              executeQuery(
+                  String.format(
+                      "source=%s  | eval a = WEEKDAY('2020-12-26 25:00:00')",
+                      TEST_INDEX_DATE_FORMATS_WITH_NULL));
         });
 
-        assertThrows(Exception.class, () -> {
-            // Code that should throw the exception
-            JSONObject actual =
-                    executeQuery(
-                            String.format(
-                                    "source=%s  | eval a = WEEKDAY('25:00:00')",
-                                    TEST_INDEX_DATE_FORMATS_WITH_NULL));
+    assertThrows(
+        Exception.class,
+        () -> {
+          // Code that should throw the exception
+          JSONObject actual =
+              executeQuery(
+                  String.format(
+                      "source=%s  | eval a = WEEKDAY('25:00:00')",
+                      TEST_INDEX_DATE_FORMATS_WITH_NULL));
         });
+  }
+
+  @Test
+  public void testWeekDayNull() {
+    JSONObject actual =
+        executeQuery(
+            String.format(
+                "source=%s  |  eval timestamp = WEEKDAY(strict_date_optional_time),"
+                    + " date=WEEKDAY(date), time=WEEKDAY(time) | fields timestamp, date, time",
+                TEST_INDEX_DATE_FORMATS_WITH_NULL));
+
+    verifySchema(
+        actual,
+        schema("timestamp", "integer"),
+        schema("date", "integer"),
+        schema("time", "integer"));
+    JSONArray ret = (JSONArray) actual.getJSONArray("datarows").get(0);
+    for (int i = 0; i < ret.length(); i++) {
+      assertEquals(JSONObject.NULL, ret.get(i));
     }
+  }
 
-    @Test
-    public void testWeekDayNull() {
-        JSONObject actual =
-                executeQuery(
-                        String.format(
-                                "source=%s  |  eval timestamp = WEEKDAY(strict_date_optional_time), date=WEEKDAY(date), time=WEEKDAY(time) | fields timestamp, date, time",
-                                TEST_INDEX_DATE_FORMATS_WITH_NULL));
-
-
-        verifySchema(
-                actual,
-                schema("timestamp", "integer"),
-                schema("date", "integer"),
-                schema("time", "integer"));
-        JSONArray ret = (JSONArray) actual.getJSONArray("datarows").get(0);
-        for (int i = 0; i < ret.length(); i++) {
-            assertEquals(JSONObject.NULL, ret.get(i));
-        }
-    }
-
-
-    @Test
-    public void testUnixTimestampInvalid() {
-        assertThrows(Exception.class, () -> {
-            // Code that should throw the exception
-            JSONObject actual =
-                    executeQuery(
-                            String.format(
-                                    "source=%s  | eval a = UNIX_TIMESTAMP('2020-15-26')",
-                                    TEST_INDEX_DATE_FORMATS_WITH_NULL));
+  @Test
+  public void testUnixTimestampInvalid() {
+    assertThrows(
+        Exception.class,
+        () -> {
+          // Code that should throw the exception
+          JSONObject actual =
+              executeQuery(
+                  String.format(
+                      "source=%s  | eval a = UNIX_TIMESTAMP('2020-15-26')",
+                      TEST_INDEX_DATE_FORMATS_WITH_NULL));
         });
-        assertThrows(Exception.class, () -> {
-            // Code that should throw the exception
-            JSONObject actual =
-                    executeQuery(
-                            String.format(
-                                    "source=%s  | eval a = UNIX_TIMESTAMP('2020-12-26 25:00:00')",
-                                    TEST_INDEX_DATE_FORMATS_WITH_NULL));
+    assertThrows(
+        Exception.class,
+        () -> {
+          // Code that should throw the exception
+          JSONObject actual =
+              executeQuery(
+                  String.format(
+                      "source=%s  | eval a = UNIX_TIMESTAMP('2020-12-26 25:00:00')",
+                      TEST_INDEX_DATE_FORMATS_WITH_NULL));
         });
+  }
+
+  @Test
+  public void testUnixTimestampNull() {
+    JSONObject actual =
+        executeQuery(
+            String.format(
+                "source=%s  |  eval timestamp = UNIX_TIMESTAMP(strict_date_optional_time),"
+                    + " date=UNIX_TIMESTAMP(date), time=UNIX_TIMESTAMP(time) | fields timestamp,"
+                    + " date, time",
+                TEST_INDEX_DATE_FORMATS_WITH_NULL));
+
+    verifySchema(
+        actual, schema("timestamp", "double"), schema("date", "double"), schema("time", "double"));
+    JSONArray ret = (JSONArray) actual.getJSONArray("datarows").get(0);
+    for (int i = 0; i < ret.length(); i++) {
+      assertEquals(JSONObject.NULL, ret.get(i));
     }
+  }
 
-    @Test
-    public void testUnixTimestampNull() {
-        JSONObject actual =
-                executeQuery(
-                        String.format(
-                                "source=%s  |  eval timestamp = UNIX_TIMESTAMP(strict_date_optional_time), date=UNIX_TIMESTAMP(date), time=UNIX_TIMESTAMP(time) | fields timestamp, date, time",
-                                TEST_INDEX_DATE_FORMATS_WITH_NULL));
-
-
-        verifySchema(
-                actual,
-                schema("timestamp", "double"),
-                schema("date", "double"),
-                schema("time", "double"));
-        JSONArray ret = (JSONArray) actual.getJSONArray("datarows").get(0);
-        for (int i = 0; i < ret.length(); i++) {
-            assertEquals(JSONObject.NULL, ret.get(i));
-        }
-    }
-
-    @Test
-    public void testToSecondsInvalid() {
-        assertThrows(Exception.class, () -> {
-            // Code that should throw the exception
-            JSONObject actual =
-                    executeQuery(
-                            String.format(
-                                    "source=%s  | eval a = UNIX_TIMESTAMP('2020-15-26')",
-                                    TEST_INDEX_DATE_FORMATS_WITH_NULL));
+  @Test
+  public void testToSecondsInvalid() {
+    assertThrows(
+        Exception.class,
+        () -> {
+          // Code that should throw the exception
+          JSONObject actual =
+              executeQuery(
+                  String.format(
+                      "source=%s  | eval a = UNIX_TIMESTAMP('2020-15-26')",
+                      TEST_INDEX_DATE_FORMATS_WITH_NULL));
         });
-        assertThrows(Exception.class, () -> {
-            // Code that should throw the exception
-            JSONObject actual =
-                    executeQuery(
-                            String.format(
-                                    "source=%s  | eval a = UNIX_TIMESTAMP('2020-12-26 25:00:00')",
-                                    TEST_INDEX_DATE_FORMATS_WITH_NULL));
+    assertThrows(
+        Exception.class,
+        () -> {
+          // Code that should throw the exception
+          JSONObject actual =
+              executeQuery(
+                  String.format(
+                      "source=%s  | eval a = UNIX_TIMESTAMP('2020-12-26 25:00:00')",
+                      TEST_INDEX_DATE_FORMATS_WITH_NULL));
         });
+  }
+
+  @Test
+  public void testToSecondsNull() {
+    JSONObject actual =
+        executeQuery(
+            String.format(
+                "source=%s  |  eval timestamp = SECOND(strict_date_optional_time),"
+                    + " date=SECOND(date) | fields timestamp, date",
+                TEST_INDEX_DATE_FORMATS_WITH_NULL));
+
+    verifySchema(actual, schema("timestamp", "integer"), schema("date", "integer"));
+    JSONArray ret = (JSONArray) actual.getJSONArray("datarows").get(0);
+    for (int i = 0; i < ret.length(); i++) {
+      assertEquals(JSONObject.NULL, ret.get(i));
     }
+  }
 
-    @Test
-    public void testToSecondsNull() {
-        JSONObject actual =
-                executeQuery(
-                        String.format(
-                                "source=%s  |  eval timestamp = SECOND(strict_date_optional_time), date=SECOND(date) | fields timestamp, date",
-                                TEST_INDEX_DATE_FORMATS_WITH_NULL));
+  @Test
+  public void testDatetimeInvalid() {
+    JSONObject actual =
+        executeQuery(
+            String.format(
+                "source=%s  |  eval timestamp = DATETIME('2025-12-01 15:02:61'),"
+                    + " date=DATETIME('2025-12-02'), time=DATETIME('16:00:61'), convert1="
+                    + " DATETIME('2025-12-01 12:02:61') | fields timestamp, date, time, convert1",
+                TEST_INDEX_DATE_FORMATS_WITH_NULL));
 
-
-        verifySchema(
-                actual,
-                schema("timestamp", "integer"),
-                schema("date", "integer"));
-        JSONArray ret = (JSONArray) actual.getJSONArray("datarows").get(0);
-        for (int i = 0; i < ret.length(); i++) {
-            assertEquals(JSONObject.NULL, ret.get(i));
-        }
+    verifySchema(
+        actual,
+        schema("timestamp", "timestamp"),
+        schema("date", "timestamp"),
+        schema("time", "timestamp"),
+        schema("convert1", "timestamp"));
+    JSONArray ret = (JSONArray) actual.getJSONArray("datarows").get(0);
+    for (int i = 0; i < ret.length(); i++) {
+      assertEquals(JSONObject.NULL, ret.get(i));
     }
+  }
 
-    @Test
-    public void testDatetimeInvalid() {
-        JSONObject actual =
-                executeQuery(
-                        String.format(
-                                "source=%s  |  eval timestamp = DATETIME('2025-12-01 15:02:61'), date=DATETIME('2025-12-02'), time=DATETIME('16:00:61'), convert1= DATETIME('2025-12-01 12:02:61') " +
-                                        "| fields timestamp, date, time, convert1",
-                                TEST_INDEX_DATE_FORMATS_WITH_NULL));
-
-
-        verifySchema(
-                actual,
-                schema("timestamp", "timestamp"),
-                schema("date", "timestamp"),
-                schema("time", "timestamp"),
-                schema("convert1", "timestamp"));
-        JSONArray ret = (JSONArray) actual.getJSONArray("datarows").get(0);
-        for (int i = 0; i < ret.length(); i++) {
-            assertEquals(JSONObject.NULL, ret.get(i));
-        }
-    }
-
-    @Test
-    public void testStrTDateInvalid1() {
-        assertThrows(Exception.class, () -> {
-            // Code that should throw the exception
-            JSONObject actual =
-                    executeQuery(
-                            String.format(
-                                    "source=%s  | eval a = str_to_date('01,13,2013', '%%d,%%m,%%Y')",
-                                    TEST_INDEX_DATE_FORMATS_WITH_NULL));
+  @Test
+  public void testStrTDateInvalid1() {
+    assertThrows(
+        Exception.class,
+        () -> {
+          // Code that should throw the exception
+          JSONObject actual =
+              executeQuery(
+                  String.format(
+                      "source=%s  | eval a = str_to_date('01,13,2013', '%%d,%%m,%%Y')",
+                      TEST_INDEX_DATE_FORMATS_WITH_NULL));
         });
+  }
+
+  @Test
+  public void testStrTDateInvalid2() {
+    JSONObject actual =
+        executeQuery(
+            String.format(
+                "source=%s  |  eval timestamp = STR_TO_DATE('2025-13-02', '2025-13-02')"
+                    + "| fields timestamp",
+                TEST_INDEX_DATE_FORMATS_WITH_NULL));
+
+    verifySchema(actual, schema("timestamp", "timestamp"));
+    JSONArray ret = (JSONArray) actual.getJSONArray("datarows").get(0);
+    for (int i = 0; i < ret.length(); i++) {
+      assertEquals(JSONObject.NULL, ret.get(i));
     }
+  }
 
-    @Test
-    public void testStrTDateInvalid2() {
-        JSONObject actual =
-                executeQuery(
-                        String.format(
-                                "source=%s  |  eval timestamp = STR_TO_DATE('2025-13-02', '2025-13-02')" +
-                                        "| fields timestamp",
-                                TEST_INDEX_DATE_FORMATS_WITH_NULL));
+  @Test
+  public void testConvertTZInvalid() {
+    JSONObject actual =
+        executeQuery(
+            String.format(
+                "source=%s  |  eval  a =CONVERT_TZ('2025-13-02', '+10:00', '-10:00'), b"
+                    + " =CONVERT_TZ('2025-10-02', '+10:00', '-10:00'), c =CONVERT_TZ('2025-12-02"
+                    + " 10:61:61', '+10:00', '-10:00'), d = CONVERT_TZ('2025-12-02 12:61:61',"
+                    + " '+10:00:00', '-10:00')| fields a, b, c, d",
+                TEST_INDEX_DATE_FORMATS_WITH_NULL));
 
-
-        verifySchema(
-                actual,
-                schema("timestamp", "timestamp"));
-        JSONArray ret = (JSONArray) actual.getJSONArray("datarows").get(0);
-        for (int i = 0; i < ret.length(); i++) {
-            assertEquals(JSONObject.NULL, ret.get(i));
-        }
+    verifySchema(
+        actual,
+        schema("a", "timestamp"),
+        schema("b", "timestamp"),
+        schema("c", "timestamp"),
+        schema("d", "timestamp"));
+    JSONArray ret = (JSONArray) actual.getJSONArray("datarows").get(0);
+    for (int i = 0; i < ret.length(); i++) {
+      assertEquals(JSONObject.NULL, ret.get(i));
     }
+  }
 
-    @Test
-    public void testConvertTZInvalid() {
-        JSONObject actual =
-                executeQuery(
-                        String.format(
-                                "source=%s  |  eval  a =CONVERT_TZ('2025-13-02', '+10:00', '-10:00'), b =CONVERT_TZ('2025-10-02', '+10:00', '-10:00'), c =CONVERT_TZ('2025-12-02 10:61:61', '+10:00', '-10:00'), " +
-                                        "d = CONVERT_TZ('2025-12-02 12:61:61', '+10:00:00', '-10:00')" +
-                                        "| fields a, b, c, d",
-                                TEST_INDEX_DATE_FORMATS_WITH_NULL));
+  @Test
+  public void testAddSubDateNull() {
+    JSONObject actual =
+        executeQuery(
+            String.format(
+                "source=%s  |  eval n1 = ADDDATE(date_time, INTERVAL 1 DAY), "
+                    + "n2 = ADDDATE(date, 1), n3 = SUBDATE(time, 1) | fields n1, n2, n3",
+                TEST_INDEX_DATE_FORMATS_WITH_NULL));
 
+    verifySchema(
+        actual, schema("n1", "timestamp"), schema("n2", "date"), schema("n3", "timestamp"));
+    verifyDataRows(actual, rows(null, null, null));
+  }
 
-        verifySchema(
-                actual,
-                schema("a", "timestamp"),
-                schema("b", "timestamp"),
-                schema("c", "timestamp"),
-                schema("d", "timestamp"));
-        JSONArray ret = (JSONArray) actual.getJSONArray("datarows").get(0);
-        for (int i = 0; i < ret.length(); i++) {
-            assertEquals(JSONObject.NULL, ret.get(i));
-        }
-    }
+  /**
+   * (DATE/TIMESTAMP, DATE/TIMESTAMP/TIME) -> TIMESTAMP
+   *
+   * <p>(TIME, DATE/TIMESTAMP/TIME) -> TIME
+   */
+  @Test
+  public void testAddTimeNull() {
+    JSONObject actual =
+        executeQuery(
+            String.format(
+                "source=%s  |  eval n1 = ADDTIME(date_time, date_time), "
+                    + "n2 = ADDTIME(date, date), n3 = ADDTIME(time, time) | fields n1, n2, n3",
+                TEST_INDEX_DATE_FORMATS_WITH_NULL));
+    verifySchema(
+        actual, schema("n1", "timestamp"), schema("n2", "timestamp"), schema("n3", "time"));
+    verifyDataRows(actual, rows(null, null, null));
+  }
 
-    @Test
-    public void testAddSubDateNull() {
-        JSONObject actual =
-                executeQuery(String.format(
-                        "source=%s  |  eval n1 = ADDDATE(date_time, INTERVAL 1 DAY), " +
-                                "n2 = ADDDATE(date, 1), n3 = SUBDATE(time, 1) | fields n1, n2, n3",
-                        TEST_INDEX_DATE_FORMATS_WITH_NULL));
+  /** (DATE/TIMESTAMP/TIME, INTERVAL) -> TIMESTAMP */
+  @Test
+  public void testDateAddSubNull() {
+    JSONObject actual =
+        executeQuery(
+            String.format(
+                "source=%s  |  eval n1 = DATE_ADD(date_time, INTERVAL 1 DAY), n2 = DATE_ADD(date,"
+                    + " INTERVAL 1 DAY), n3 = DATE_SUB(time, INTERVAL 1 DAY) | fields n1, n2, n3",
+                TEST_INDEX_DATE_FORMATS_WITH_NULL));
+    verifySchema(
+        actual, schema("n1", "timestamp"), schema("n2", "timestamp"), schema("n3", "timestamp"));
+    verifyDataRows(actual, rows(null, null, null));
+  }
 
-        verifySchema(actual, schema("n1", "timestamp"),
-                schema("n2", "date"),
-                schema("n3", "timestamp"));
-        verifyDataRows(actual, rows(null, null, null));
-    }
+  /*
+  STRING/DATE/TIMESTAMP
+   */
+  @Test
+  public void testDateNull() {
+    JSONObject actual =
+        executeQuery(
+            String.format(
+                "source=%s  |  eval d1 = DATE(date), d2 = DATE(date_time) | fields d1, d2",
+                TEST_INDEX_DATE_FORMATS_WITH_NULL));
 
-    /**
-     * (DATE/TIMESTAMP, DATE/TIMESTAMP/TIME) -> TIMESTAMP
-     *
-     * (TIME, DATE/TIMESTAMP/TIME) -> TIME
-     */
-    @Test
-    public void testAddTimeNull() {
-        JSONObject actual =
-                executeQuery(String.format(
-                        "source=%s  |  eval n1 = ADDTIME(date_time, date_time), " +
-                                "n2 = ADDTIME(date, date), n3 = ADDTIME(time, time) | fields n1, n2, n3",
-                        TEST_INDEX_DATE_FORMATS_WITH_NULL));
-        verifySchema(actual, schema("n1", "timestamp"),
-                schema("n2", "timestamp"),
-                schema("n3", "time"));
-        verifyDataRows(actual, rows(null, null, null));
-    }
+    verifySchema(actual, schema("d1", "date"), schema("d2", "date"));
 
-    /**
-     * (DATE/TIMESTAMP/TIME, INTERVAL) -> TIMESTAMP
-     */
-    @Test
-    public void testDateAddSubNull() {
-        JSONObject actual =
-                executeQuery(String.format(
-                        "source=%s  |  eval n1 = DATE_ADD(date_time, INTERVAL 1 DAY), " +
-                                "n2 = DATE_ADD(date, INTERVAL 1 DAY), n3 = DATE_SUB(time, INTERVAL 1 DAY) | fields n1, n2, n3",
-                        TEST_INDEX_DATE_FORMATS_WITH_NULL));
-        verifySchema(actual, schema("n1", "timestamp"),
-                schema("n2", "timestamp"),
-                schema("n3", "timestamp"));
-        verifyDataRows(actual, rows(null, null, null));
-    }
+    verifyDataRows(actual, rows(null, null));
+  }
 
-    /*
-    STRING/DATE/TIMESTAMP
-     */
-    @Test
-    public void testDateNull() {
-        JSONObject actual =
-                executeQuery(
-                        String.format(
-                                "source=%s  |  eval d1 = DATE(date), d2 = DATE(date_time) | fields d1, d2",
-                                TEST_INDEX_DATE_FORMATS_WITH_NULL));
-
-        verifySchema(actual, schema("d1", "date"), schema("d2", "date"));
-
-        verifyDataRows(actual, rows(null, null));
-    }
-
-    @Test
-    public void testDateInvalid() {
-        Exception semanticException = assertThrows(
-                SemanticCheckException.class,
-                () -> executeQuery(
-                        String.format(
-                                "source=%s  | eval d1 = DATE('2020-08-26'), d2 = DATE('2020-15-26') | fields d1, d2",
-                                TEST_INDEX_DATE_FORMATS_WITH_NULL)));
-        verifyErrorMessageContains(semanticException, "date:2020-15-26 in unsupported format, please use 'yyyy-MM-dd'");
-    }
-
-    /**
-     * STRING/TIME/TIMESTAMP -> INTEGER
-     */
-    @Test
-    public void testHourNull() {
-        JSONObject actual =
-                executeQuery(
-                        String.format(
-                                "source=%s  |  eval h2 = HOUR(date_time), h3 = HOUR(time) | fields h2, h3",
-                                TEST_INDEX_DATE_FORMATS_WITH_NULL));
-        verifySchema(actual, schema("h2", "integer"), schema("h3", "integer"));
-        verifyDataRows(actual, rows(null, null));
-    }
-
-    @Test
-    public void testHourInvalid() {
-        Exception semanticException = assertThrows(
-                SemanticCheckException.class,
-                () -> executeQuery(
-                        String.format(
-                                "source=%s  | eval h1 = HOUR('2020-08-26') | fields h1",
-                                TEST_INDEX_DATE_FORMATS_WITH_NULL)));
-        verifyErrorMessageContains(semanticException, "time:2020-08-26 in unsupported format, please use 'HH:mm:ss[.SSSSSSSSS]'");
-    }
-
-    @Test
-    public void testDayInvalid() {
-        Exception malformMonthException = assertThrows(
-                SemanticCheckException.class,
-                () -> executeQuery(
-                        String.format(
-                                "source=%s  | eval d1 = DAY('2020-13-26') | fields d1",
-                                TEST_INDEX_DATE_FORMATS_WITH_NULL)));
-        verifyErrorMessageContains(malformMonthException, "date:2020-13-26 in unsupported format, please use 'yyyy-MM-dd'");
-
-        Exception dateAsTimeException = assertThrows(
-                SemanticCheckException.class,
-                () -> executeQuery(
-                        String.format(
-                                "source=%s  | eval d2 = DAY('12:00:00') | fields d2",
-                                TEST_INDEX_DATE_FORMATS_WITH_NULL)));
-        verifyErrorMessageContains(dateAsTimeException, "date:12:00:00 in unsupported format, please use 'yyyy-MM-dd'");
-    }
-
-    @Test
-    public void testTimeInvalid() {
+  @Test
+  public void testDateInvalid() {
+    Exception semanticException =
         assertThrows(
-                SemanticCheckException.class,
-                () -> executeQuery(
-                        String.format(
-                                "source=%s  | eval t1 = TIME('13:69:00') | fields t1",
-                                TEST_INDEX_DATE_FORMATS_WITH_NULL)));
-    }
-
-
-    @Test
-    public void testDayOfWeekNull() {
-        JSONObject actual =
-                executeQuery(String.format(
-                        "source=%s | eval d1 = DAY_OF_WEEK(date), d2 = DAYOFWEEK(date_time) | fields d1, d2",
-                        TEST_INDEX_DATE_FORMATS_WITH_NULL));
-        verifySchema(actual, schema("d1", "integer"),
-                schema("d2", "integer"));
-        verifyDataRows(actual, rows(null, null));
-    }
-
-    @Test
-    public void testDayOfYearNull() {
-        JSONObject actual =
-                executeQuery(String.format(
-                        "source=%s | eval d1 = DAY_OF_YEAR(date), d2 = DAYOFYEAR(date_time) | fields d1, d2",
-                        TEST_INDEX_DATE_FORMATS_WITH_NULL));
-        verifySchema(actual, schema("d1", "integer"),
-                schema("d2", "integer"));
-        verifyDataRows(actual, rows(null, null));
-    }
-
-
-    @Test
-    public void testExtractNull() {
-        JSONObject actual =
-                executeQuery(String.format(
-                        "source=%s | eval e1 = EXTRACT(YEAR FROM date), e2 = EXTRACT(MONTH FROM date_time), e3 = EXTRACT(HOUR FROM time) | fields e1, e2, e3",
-                        TEST_INDEX_DATE_FORMATS_WITH_NULL));
-        verifySchema(actual, schema("e1", "long"),
-                schema("e2", "long"),
-                schema("e3", "long"));
-        verifyDataRows(actual, rows(null, null, null));
-    }
-
-
-    @Test
-    public void testFromDaysNull() {
-        JSONObject actual =
-                executeQuery(String.format(
-                        "source=%s | eval from1 = FROM_DAYS(TO_DAYS(date)), from2 = FROM_DAYS(TO_DAYS(date_time)) | fields from1, from2",
-                        TEST_INDEX_DATE_FORMATS_WITH_NULL));
-        verifySchema(actual, schema("from1", "date"),
-                schema("from2", "date"));
-        verifyDataRows(actual, rows(null, null));
-    }
-
-
-    @Test
-    public void testFromUnixtimeNull() {
-        JSONObject actual =
-                executeQuery(String.format(
-                        "source=%s | eval f1 = FROM_UNIXTIME(UNIX_TIMESTAMP(date_time)), f2 = FROM_UNIXTIME(UNIX_TIMESTAMP(date)) | fields f1, f2",
-                        TEST_INDEX_DATE_FORMATS_WITH_NULL));
-        verifySchema(actual, schema("f1", "timestamp"),
-                schema("f2", "timestamp"));
-        verifyDataRows(actual, rows(null, null));
-    }
-
-    @Test
-    public void testHourOfDayNull() {
-        JSONObject actual =
-                executeQuery(String.format(
-                        "source=%s | eval h1 = HOUR_OF_DAY(time), h2 = HOUR_OF_DAY(date_time) | fields h1, h2",
-                        TEST_INDEX_DATE_FORMATS_WITH_NULL));
-        verifySchema(actual, schema("h1", "integer"),
-                schema("h2", "integer"));
-        verifyDataRows(actual, rows(null, null));
-    }
-
-
-    @Test
-    public void testLastDayNull() {
-        JSONObject actual =
-                executeQuery(String.format(
-                        "source=%s | eval l1 = LAST_DAY(date), l2 = LAST_DAY(date_time) | fields l1, l2",
-                        TEST_INDEX_DATE_FORMATS_WITH_NULL));
-        verifySchema(actual, schema("l1", "date"),
-                schema("l2", "date"));
-        verifyDataRows(actual, rows(null, null));
-    }
-
-
-    @Test
-    public void testMakedateNull() {
-        JSONObject actual =
-                executeQuery(String.format(
-                        "source=%s | eval mk1 = MAKEDATE(YEAR(date), DAYOFYEAR(date)), mk2 = MAKEDATE(YEAR(date_time), DAYOFYEAR(date_time)) | fields mk1, mk2",
-                        TEST_INDEX_DATE_FORMATS_WITH_NULL));
-        verifySchema(actual, schema("mk1", "date"),
-                schema("mk2", "date"));
-        verifyDataRows(actual, rows(null, null));
-    }
-
-
-    @Test
-    public void testMaketimeNull() {
-        JSONObject actual =
-                executeQuery(String.format(
-                        "source=%s | eval mt1 = MAKETIME(HOUR(date_time), MINUTE(date_time), SECOND(date_time)), mt2 = MAKETIME(HOUR(time), MINUTE(time), SECOND(time)) | fields mt1, mt2",
-                        TEST_INDEX_DATE_FORMATS_WITH_NULL));
-        verifySchema(actual, schema("mt1", "time"),
-                schema("mt2", "time"));
-        verifyDataRows(actual, rows(null, null));
-    }
-
-
-    @Test
-    public void testAdddateNull() {
-        JSONObject actual =
-                executeQuery(String.format(
-                        "source=%s | eval a1 = ADDDATE(date, 3), a2 = ADDDATE(date_time, 3) | fields a1, a2",
-                        TEST_INDEX_DATE_FORMATS_WITH_NULL));
-        verifySchema(actual, schema("a1", "date"),
-                schema("a2", "timestamp"));
-        verifyDataRows(actual, rows(null, null));
-    }
-
-
-    @Test
-    public void testAddtimeNull() {
-        JSONObject actual =
-                executeQuery(String.format(
-                        "source=%s | eval n1 = ADDTIME(date_time, date_time), n2 = ADDTIME(date, date), n3 = ADDTIME(time, time) | fields n1, n2, n3",
-                        TEST_INDEX_DATE_FORMATS_WITH_NULL));
-        verifySchema(actual, schema("n1", "timestamp"),
-                schema("n2", "timestamp"),
-                schema("n3", "time"));
-        verifyDataRows(actual, rows(null, null, null));
-    }
-
-
-    @Test
-    public void testConvertTzNull() {
-        JSONObject actual =
-                executeQuery(String.format(
-                        "source=%s | eval c1 = CONVERT_TZ(date, '+00:00', '+08:00'), c2 = CONVERT_TZ(date, '-03:00', '+01:30') | fields c1, c2",
-                        TEST_INDEX_DATE_FORMATS_WITH_NULL));
-        verifySchema(actual, schema("c1", "timestamp"),
-                schema("c2", "timestamp"));
-        verifyDataRows(actual, rows(null, null));
-    }
-
-
-    @Test
-    public void testDateAddNull() {
-        JSONObject actual =
-                executeQuery(String.format(
-                        "source=%s | eval da1 = DATE_ADD(date, INTERVAL 1 DAY), da2 = DATE_ADD(date_time, interval 5 month) | fields da1, da2",
-                        TEST_INDEX_DATE_FORMATS_WITH_NULL));
-        verifySchema(actual, schema("da1", "timestamp"),
-                schema("da2", "timestamp"));
-        verifyDataRows(actual, rows(null, null));
-    }
-
-
-    @Test
-    public void testDateFormatNull() {
-        JSONObject actual =
-                executeQuery(String.format(
-                        "source=%s | eval df1 = DATE_FORMAT(date, 'yyyy-MM-dd'), df2 = DATE_FORMAT(date_time, 'yyyy-MM-dd HH:mm:ss') | fields df1, df2",
-                        TEST_INDEX_DATE_FORMATS_WITH_NULL));
-        verifySchema(actual, schema("df1", "string"),
-                schema("df2", "string"));
-        verifyDataRows(actual, rows(null, null));
-    }
-
-
-    @Test
-    public void testDateSubNull() {
-        JSONObject actual =
-                executeQuery(String.format(
-                        "source=%s | eval ds1 = DATE_SUB(date, INTERVAL 1 DAY), ds2 = DATE_SUB(date_time, interval 5 month) | fields ds1, ds2",
-                        TEST_INDEX_DATE_FORMATS_WITH_NULL));
-        verifySchema(actual, schema("ds1", "timestamp"),
-                schema("ds2", "timestamp"));
-        verifyDataRows(actual, rows(null, null));
-    }
-
-
-    @Test
-    public void testDatediffNull() {
-        JSONObject actual =
-                executeQuery(String.format(
-                        "source=%s | eval diff1 = DATEDIFF(date, date), diff2 = DATEDIFF(date_time, date_time) | fields diff1, diff2",
-                        TEST_INDEX_DATE_FORMATS_WITH_NULL));
-        verifySchema(actual, schema("diff1", "long"),
-                schema("diff2", "long"));
-        verifyDataRows(actual, rows(null, null));
-    }
-
-    @Test
-    public void testDatetimeNullString() {
-        JSONObject actual =
-                executeQuery(String.format(
-                        "source=%s | where age = 10 | eval d1 = DATETIME(name, '+10:00'), d2 = datetime('2004-02-28 23:00:00-10:00', state)" +
-                                "| fields d1, d2",
-                        TEST_INDEX_STATE_COUNTRY_WITH_NULL));
-        verifySchema(actual, schema("d1", "timestamp"),
-                schema("d2", "timestamp"));
-        verifyDataRows(actual, rows(null, null));
-    }
-
-    @Test
-    public void testDatetimeNullTimestamp() {
-        JSONObject actual =
-                executeQuery(String.format(
-                        "source=%s | eval d1 = DATETIME(date_time) | fields d1",
-                        TEST_INDEX_DATE_FORMATS_WITH_NULL));
-        verifySchema(actual, schema("d1", "timestamp"));
-        verifyDataRows(actual, rows((Object) null));
-    }
-
-
-    @Test
-    public void testDayNull() {
-        JSONObject actual =
-                executeQuery(String.format(
-                        "source=%s | eval d1 = DAY(date), d2 = DAY(date_time) | fields d1, d2",
-                        TEST_INDEX_DATE_FORMATS_WITH_NULL));
-        verifySchema(actual, schema("d1", "integer"),
-                schema("d2", "integer"));
-        verifyDataRows(actual, rows(null, null));
-    }
-
-
-    @Test
-    public void testDaynameNull() {
-        JSONObject actual =
-                executeQuery(String.format(
-                        "source=%s | eval d1 = DAYNAME(date), d2 = DAYNAME(date_time) | fields d1, d2",
-                        TEST_INDEX_DATE_FORMATS_WITH_NULL));
-        verifySchema(actual, schema("d1", "string"),
-                schema("d2", "string"));
-        verifyDataRows(actual, rows(null, null));
-    }
-
-
-    @Test
-    public void testDayOfMonthNull() {
-        JSONObject actual =
-                executeQuery(String.format(
-                        "source=%s | eval d1 = DAY_OF_MONTH(date), d2 = DAYOFMONTH(date_time) | fields d1, d2",
-                        TEST_INDEX_DATE_FORMATS_WITH_NULL));
-        verifySchema(actual, schema("d1", "integer"),
-                schema("d2", "integer"));
-        verifyDataRows(actual, rows(null, null));
-    }
-
-    @Ignore
-    @Test
-    public void testMicrosecondNull() {
-        JSONObject actual =
-                executeQuery(String.format(
-                        "source=%s | eval m1 = MICROSECOND(time), m2 = MICROSECOND(date_time) | fields m1, m2",
-                        TEST_INDEX_DATE_FORMATS_WITH_NULL));
-        verifySchema(actual, schema("m1", "integer"),
-                schema("m2", "integer"));
-        verifyDataRows(actual, rows(null, null));
-    }
-
-
-    @Test
-    public void testMinuteNull() {
-        JSONObject actual =
-                executeQuery(String.format(
-                        "source=%s | eval m1 = MINUTE(time), m2 = MINUTE(date_time) | fields m1, m2",
-                        TEST_INDEX_DATE_FORMATS_WITH_NULL));
-        verifySchema(actual, schema("m1", "integer"),
-                schema("m2", "integer"));
-        verifyDataRows(actual, rows(null, null));
-    }
-
-
-    @Test
-    public void testMinuteOfDayNull() {
-        JSONObject actual =
-                executeQuery(String.format(
-                        "source=%s | eval md1 = MINUTE_OF_DAY(time), md2 = MINUTE_OF_DAY(date_time) | fields md1, md2",
-                        TEST_INDEX_DATE_FORMATS_WITH_NULL));
-        verifySchema(actual, schema("md1", "integer"),
-                schema("md2", "integer"));
-        verifyDataRows(actual, rows(null, null));
-    }
-
-
-    @Test
-    public void testMinuteOfHourNull() {
-        JSONObject actual =
-                executeQuery(String.format(
-                        "source=%s | eval mh1 = MINUTE_OF_HOUR(time), mh2 = MINUTE_OF_HOUR(date_time) | fields mh1, mh2",
-                        TEST_INDEX_DATE_FORMATS_WITH_NULL));
-        verifySchema(actual, schema("mh1", "integer"),
-                schema("mh2", "integer"));
-        verifyDataRows(actual, rows(null, null));
-    }
-
-
-    @Test
-    public void testMonthNull() {
-        JSONObject actual =
-                executeQuery(String.format(
-                        "source=%s | eval mo1 = MONTH(date), mo2 = MONTH(date_time) | fields mo1, mo2",
-                        TEST_INDEX_DATE_FORMATS_WITH_NULL));
-        verifySchema(actual, schema("mo1", "integer"),
-                schema("mo2", "integer"));
-        verifyDataRows(actual, rows(null, null));
-    }
-
-
-    @Test
-    public void testMonthOfYearNull() {
-        JSONObject actual =
-                executeQuery(String.format(
-                        "source=%s | eval mo1 = MONTH_OF_YEAR(date), mo2 = MONTH_OF_YEAR(date_time) | fields mo1, mo2",
-                        TEST_INDEX_DATE_FORMATS_WITH_NULL));
-        verifySchema(actual, schema("mo1", "integer"),
-                schema("mo2", "integer"));
-        verifyDataRows(actual, rows(null, null));
-    }
-
-
-    @Test
-    public void testMonthnameNull() {
-        JSONObject actual =
-                executeQuery(String.format(
-                        "source=%s | eval mn1 = MONTHNAME(date), mn2 = MONTHNAME(date_time) | fields mn1, mn2",
-                        TEST_INDEX_DATE_FORMATS_WITH_NULL));
-        verifySchema(actual, schema("mn1", "string"),
-                schema("mn2", "string"));
-        verifyDataRows(actual, rows(null, null));
-    }
-
-    @Test
-    public void testPeriodAddDiffNull() {
-        JSONObject actual =
-                executeQuery(String.format(
-                        "source=%s | where key='null' | head 1 | eval pa1 = PERIOD_ADD(`int`, 3), pa2 = PERIOD_DIFF(`int`, `int`) | fields pa1, pa2",
-                        TEST_INDEX_NULL_MISSING));
-
-        verifySchema(actual, schema("pa1", "integer"),
-                schema("pa2", "integer"));
-        verifyDataRows(actual, rows(null, null));
-    }
-
-
-    @Test
-    public void testQuarterNull() {
-        JSONObject actual =
-                executeQuery(String.format(
-                        "source=%s | eval q1 = QUARTER(date), q2 = QUARTER(date_time) | fields q1, q2",
-                        TEST_INDEX_DATE_FORMATS_WITH_NULL));
-        verifySchema(actual, schema("q1", "integer"),
-                schema("q2", "integer"));
-        verifyDataRows(actual, rows(null, null));
-    }
-
-
-    @Test
-    public void testSecToTimeNull() {
-        JSONObject actual =
-                executeQuery(String.format(
-                        "source=%s | eval st1 = SEC_TO_TIME(UNIX_TIMESTAMP(date_time)), st2 = SEC_TO_TIME(UNIX_TIMESTAMP(date)) | fields st1, st2",
-                        TEST_INDEX_DATE_FORMATS_WITH_NULL));
-        verifySchema(actual, schema("st1", "time"),
-                schema("st2", "time"));
-        verifyDataRows(actual, rows(null, null));
-    }
-
-
-    @Test
-    public void testSecondNull() {
-        JSONObject actual =
-                executeQuery(String.format(
-                        "source=%s | eval s1 = SECOND(time), s2 = SECOND(date_time) | fields s1, s2",
-                        TEST_INDEX_DATE_FORMATS_WITH_NULL));
-        verifySchema(actual, schema("s1", "integer"),
-                schema("s2", "integer"));
-        verifyDataRows(actual, rows(null, null));
-    }
-
-
-    @Test
-    public void testSecondOfMinuteNull() {
-        JSONObject actual =
-                executeQuery(String.format(
-                        "source=%s | eval s1 = SECOND_OF_MINUTE(time), s2 = SECOND_OF_MINUTE(date_time) | fields s1, s2",
-                        TEST_INDEX_DATE_FORMATS_WITH_NULL));
-        verifySchema(actual, schema("s1", "integer"),
-                schema("s2", "integer"));
-        verifyDataRows(actual, rows(null, null));
-    }
-
-
-    @Test
-    public void testStrToDateNull() {
-        JSONObject actual =
-                executeQuery(String.format(
-                        "source=%s | eval s = STR_TO_DATE(MONTHNAME(date_time), '%%M') | fields s",
-                        TEST_INDEX_DATE_FORMATS_WITH_NULL));
-        verifySchema(actual, schema("s", "timestamp"));
-        verifyDataRows(actual, rows((Object) null));
-    }
-
-
-    @Test
-    public void testSubdateNull() {
-        JSONObject actual =
-                executeQuery(String.format(
-                        "source=%s | eval sd1 = SUBDATE(date, 3), sd2 = SUBDATE(date_time, 5) | fields sd1, sd2",
-                        TEST_INDEX_DATE_FORMATS_WITH_NULL));
-        verifySchema(actual, schema("sd1", "date"),
-                schema("sd2", "timestamp"));
-        verifyDataRows(actual, rows(null, null));
-    }
-
-
-    @Test
-    public void testSubtimeNull() {
-        JSONObject actual =
-                executeQuery(String.format(
-                        "source=%s | eval s1 = SUBTIME(date_time, date_time), s2 = SUBTIME(date, date), s3 = SUBTIME(time, time) | fields s1, s2, s3",
-                        TEST_INDEX_DATE_FORMATS_WITH_NULL));
-        verifySchema(actual, schema("s1", "timestamp"),
-                schema("s2", "timestamp"),
-                schema("s3", "time"));
-        verifyDataRows(actual, rows(null, null, null));
-    }
-
-
-    @Test
-    public void testTimeNull() {
-        JSONObject actual =
-                executeQuery(String.format(
-                        "source=%s | eval t1 = TIME(date_time) | fields t1",
-                        TEST_INDEX_DATE_FORMATS_WITH_NULL));
-        verifySchema(actual, schema("t1", "time"));
-        verifyDataRows(actual, rows((Object) null));
-    }
-
-
-    @Test
-    public void testTimeFormatNull() {
-        JSONObject actual =
-                executeQuery(String.format(
-                        "source=%s | eval tf1 = TIME_FORMAT(time, '%%H:%%i:%%s') | fields tf1",
-                        TEST_INDEX_DATE_FORMATS_WITH_NULL));
-        verifySchema(actual, schema("tf1", "string"));
-        verifyDataRows(actual, rows((Object) null));
-    }
-
-
-    @Test
-    public void testTimeToSecNull() {
-        JSONObject actual =
-                executeQuery(String.format(
-                        "source=%s | eval ts1 = TIME_TO_SEC(time) | fields ts1",
-                        TEST_INDEX_DATE_FORMATS_WITH_NULL));
-        verifySchema(actual, schema("ts1", "long"));
-        verifyDataRows(actual, rows((Object) null));
-    }
-
-
-    @Test
-    public void testTimediffNull() {
-        JSONObject actual =
-                executeQuery(String.format(
-                        "source=%s | eval td1 = TIMEDIFF(time, time) | fields td1",
-                        TEST_INDEX_DATE_FORMATS_WITH_NULL));
-        verifySchema(actual, schema("td1", "time"));
-        verifyDataRows(actual, rows((Object) null));
-    }
-
-
-    @Test
-    public void testTimestampNull() {
-        JSONObject actual =
-                executeQuery(String.format(
-                        "source=%s | eval t1 = TIMESTAMP(date, time), t2 = TIMESTAMP(date_time) | fields t1, t2",
-                        TEST_INDEX_DATE_FORMATS_WITH_NULL));
-        verifySchema(actual, schema("t1", "timestamp"),
-                schema("t2", "timestamp"));
-        verifyDataRows(actual, rows(null, null));
-    }
-
-
-    @Test
-    public void testTimestampaddNull() {
-        JSONObject actual =
-                executeQuery(String.format(
-                        "source=%s | eval ta1 = TIMESTAMPADD(MONTH, 2, date), ta2 = TIMESTAMPADD(HOUR, 3, date_time) | fields ta1, ta2",
-                        TEST_INDEX_DATE_FORMATS_WITH_NULL));
-        verifySchema(actual, schema("ta1", "timestamp"),
-                schema("ta2", "timestamp"));
-        verifyDataRows(actual, rows(null, null));
-    }
-
-
-    @Test
-    public void testTimestampdiffNull() {
-        JSONObject actual =
-                executeQuery(String.format(
-                        "source=%s | eval td1 = TIMESTAMPDIFF(DAY, date, date_time), td2 = TIMESTAMPDIFF(HOUR, date_time, date_time) | fields td1, td2",
-                        TEST_INDEX_DATE_FORMATS_WITH_NULL));
-        verifySchema(actual, schema("td1", "long"),
-                schema("td2", "long"));
-        verifyDataRows(actual, rows(null, null));
-    }
-
-
-    @Test
-    public void testToDaysNull() {
-        JSONObject actual =
-                executeQuery(String.format(
-                        "source=%s | eval td1 = TO_DAYS(date), td2 = TO_DAYS(date_time) | fields td1, td2",
-                        TEST_INDEX_DATE_FORMATS_WITH_NULL));
-        verifySchema(actual, schema("td1", "long"),
-                schema("td2", "long"));
-        verifyDataRows(actual, rows(null, null));
-    }
-
-
-    @Test
-    public void testWeekNull() {
-        JSONObject actual =
-                executeQuery(String.format(
-                        "source=%s | eval w1 = WEEK(date), w2 = WEEK(date_time) | fields w1, w2",
-                        TEST_INDEX_DATE_FORMATS_WITH_NULL));
-        verifySchema(actual, schema("w1", "integer"),
-                schema("w2", "integer"));
-        verifyDataRows(actual, rows(null, null));
-    }
-
-
-    @Test
-    public void testWeekdayNull() {
-        JSONObject actual =
-                executeQuery(String.format(
-                        "source=%s | eval wd1 = WEEKDAY(date), wd2 = WEEKDAY(date_time) | fields wd1, wd2",
-                        TEST_INDEX_DATE_FORMATS_WITH_NULL));
-        verifySchema(actual, schema("wd1", "integer"),
-                schema("wd2", "integer"));
-        verifyDataRows(actual, rows(null, null));
-    }
-
-
-    @Test
-    public void testWeekOfYearNull() {
-        JSONObject actual =
-                executeQuery(String.format(
-                        "source=%s | eval wy1 = WEEK_OF_YEAR(date), wy2 = WEEK_OF_YEAR(date_time) | fields wy1, wy2",
-                        TEST_INDEX_DATE_FORMATS_WITH_NULL));
-        verifySchema(actual, schema("wy1", "integer"),
-                schema("wy2", "integer"));
-        verifyDataRows(actual, rows(null, null));
-    }
-
-
-    @Test
-    public void testYearNull() {
-        JSONObject actual =
-                executeQuery(String.format(
-                        "source=%s | eval y1 = YEAR(date), y2 = YEAR(date_time) | fields y1, y2",
-                        TEST_INDEX_DATE_FORMATS_WITH_NULL));
-        verifySchema(actual, schema("y1", "integer"),
-                schema("y2", "integer"));
-        verifyDataRows(actual, rows(null, null));
-    }
+            SemanticCheckException.class,
+            () ->
+                executeQuery(
+                    String.format(
+                        "source=%s  | eval d1 = DATE('2020-08-26'), d2 = DATE('2020-15-26') |"
+                            + " fields d1, d2",
+                        TEST_INDEX_DATE_FORMATS_WITH_NULL)));
+    verifyErrorMessageContains(
+        semanticException, "date:2020-15-26 in unsupported format, please use 'yyyy-MM-dd'");
+  }
+
+  /** STRING/TIME/TIMESTAMP -> INTEGER */
+  @Test
+  public void testHourNull() {
+    JSONObject actual =
+        executeQuery(
+            String.format(
+                "source=%s  |  eval h2 = HOUR(date_time), h3 = HOUR(time) | fields h2, h3",
+                TEST_INDEX_DATE_FORMATS_WITH_NULL));
+    verifySchema(actual, schema("h2", "integer"), schema("h3", "integer"));
+    verifyDataRows(actual, rows(null, null));
+  }
+
+  @Test
+  public void testHourInvalid() {
+    Exception semanticException =
+        assertThrows(
+            SemanticCheckException.class,
+            () ->
+                executeQuery(
+                    String.format(
+                        "source=%s  | eval h1 = HOUR('2020-08-26') | fields h1",
+                        TEST_INDEX_DATE_FORMATS_WITH_NULL)));
+    verifyErrorMessageContains(
+        semanticException,
+        "time:2020-08-26 in unsupported format, please use 'HH:mm:ss[.SSSSSSSSS]'");
+  }
+
+  @Test
+  public void testDayInvalid() {
+    Exception malformMonthException =
+        assertThrows(
+            SemanticCheckException.class,
+            () ->
+                executeQuery(
+                    String.format(
+                        "source=%s  | eval d1 = DAY('2020-13-26') | fields d1",
+                        TEST_INDEX_DATE_FORMATS_WITH_NULL)));
+    verifyErrorMessageContains(
+        malformMonthException, "date:2020-13-26 in unsupported format, please use 'yyyy-MM-dd'");
+
+    Exception dateAsTimeException =
+        assertThrows(
+            SemanticCheckException.class,
+            () ->
+                executeQuery(
+                    String.format(
+                        "source=%s  | eval d2 = DAY('12:00:00') | fields d2",
+                        TEST_INDEX_DATE_FORMATS_WITH_NULL)));
+    verifyErrorMessageContains(
+        dateAsTimeException, "date:12:00:00 in unsupported format, please use 'yyyy-MM-dd'");
+  }
+
+  @Test
+  public void testTimeInvalid() {
+    assertThrows(
+        SemanticCheckException.class,
+        () ->
+            executeQuery(
+                String.format(
+                    "source=%s  | eval t1 = TIME('13:69:00') | fields t1",
+                    TEST_INDEX_DATE_FORMATS_WITH_NULL)));
+  }
+
+  @Test
+  public void testDayOfWeekNull() {
+    JSONObject actual =
+        executeQuery(
+            String.format(
+                "source=%s | eval d1 = DAY_OF_WEEK(date), d2 = DAYOFWEEK(date_time) | fields d1,"
+                    + " d2",
+                TEST_INDEX_DATE_FORMATS_WITH_NULL));
+    verifySchema(actual, schema("d1", "integer"), schema("d2", "integer"));
+    verifyDataRows(actual, rows(null, null));
+  }
+
+  @Test
+  public void testDayOfYearNull() {
+    JSONObject actual =
+        executeQuery(
+            String.format(
+                "source=%s | eval d1 = DAY_OF_YEAR(date), d2 = DAYOFYEAR(date_time) | fields d1,"
+                    + " d2",
+                TEST_INDEX_DATE_FORMATS_WITH_NULL));
+    verifySchema(actual, schema("d1", "integer"), schema("d2", "integer"));
+    verifyDataRows(actual, rows(null, null));
+  }
+
+  @Test
+  public void testExtractNull() {
+    JSONObject actual =
+        executeQuery(
+            String.format(
+                "source=%s | eval e1 = EXTRACT(YEAR FROM date), e2 = EXTRACT(MONTH FROM date_time),"
+                    + " e3 = EXTRACT(HOUR FROM time) | fields e1, e2, e3",
+                TEST_INDEX_DATE_FORMATS_WITH_NULL));
+    verifySchema(actual, schema("e1", "long"), schema("e2", "long"), schema("e3", "long"));
+    verifyDataRows(actual, rows(null, null, null));
+  }
+
+  @Test
+  public void testFromDaysNull() {
+    JSONObject actual =
+        executeQuery(
+            String.format(
+                "source=%s | eval from1 = FROM_DAYS(TO_DAYS(date)), from2 ="
+                    + " FROM_DAYS(TO_DAYS(date_time)) | fields from1, from2",
+                TEST_INDEX_DATE_FORMATS_WITH_NULL));
+    verifySchema(actual, schema("from1", "date"), schema("from2", "date"));
+    verifyDataRows(actual, rows(null, null));
+  }
+
+  @Test
+  public void testFromUnixtimeNull() {
+    JSONObject actual =
+        executeQuery(
+            String.format(
+                "source=%s | eval f1 = FROM_UNIXTIME(UNIX_TIMESTAMP(date_time)), f2 ="
+                    + " FROM_UNIXTIME(UNIX_TIMESTAMP(date)) | fields f1, f2",
+                TEST_INDEX_DATE_FORMATS_WITH_NULL));
+    verifySchema(actual, schema("f1", "timestamp"), schema("f2", "timestamp"));
+    verifyDataRows(actual, rows(null, null));
+  }
+
+  @Test
+  public void testHourOfDayNull() {
+    JSONObject actual =
+        executeQuery(
+            String.format(
+                "source=%s | eval h1 = HOUR_OF_DAY(time), h2 = HOUR_OF_DAY(date_time) | fields h1,"
+                    + " h2",
+                TEST_INDEX_DATE_FORMATS_WITH_NULL));
+    verifySchema(actual, schema("h1", "integer"), schema("h2", "integer"));
+    verifyDataRows(actual, rows(null, null));
+  }
+
+  @Test
+  public void testLastDayNull() {
+    JSONObject actual =
+        executeQuery(
+            String.format(
+                "source=%s | eval l1 = LAST_DAY(date), l2 = LAST_DAY(date_time) | fields l1, l2",
+                TEST_INDEX_DATE_FORMATS_WITH_NULL));
+    verifySchema(actual, schema("l1", "date"), schema("l2", "date"));
+    verifyDataRows(actual, rows(null, null));
+  }
+
+  @Test
+  public void testMakedateNull() {
+    JSONObject actual =
+        executeQuery(
+            String.format(
+                "source=%s | eval mk1 = MAKEDATE(YEAR(date), DAYOFYEAR(date)), mk2 ="
+                    + " MAKEDATE(YEAR(date_time), DAYOFYEAR(date_time)) | fields mk1, mk2",
+                TEST_INDEX_DATE_FORMATS_WITH_NULL));
+    verifySchema(actual, schema("mk1", "date"), schema("mk2", "date"));
+    verifyDataRows(actual, rows(null, null));
+  }
+
+  @Test
+  public void testMaketimeNull() {
+    JSONObject actual =
+        executeQuery(
+            String.format(
+                "source=%s | eval mt1 = MAKETIME(HOUR(date_time), MINUTE(date_time),"
+                    + " SECOND(date_time)), mt2 = MAKETIME(HOUR(time), MINUTE(time), SECOND(time))"
+                    + " | fields mt1, mt2",
+                TEST_INDEX_DATE_FORMATS_WITH_NULL));
+    verifySchema(actual, schema("mt1", "time"), schema("mt2", "time"));
+    verifyDataRows(actual, rows(null, null));
+  }
+
+  @Test
+  public void testAdddateNull() {
+    JSONObject actual =
+        executeQuery(
+            String.format(
+                "source=%s | eval a1 = ADDDATE(date, 3), a2 = ADDDATE(date_time, 3) | fields a1,"
+                    + " a2",
+                TEST_INDEX_DATE_FORMATS_WITH_NULL));
+    verifySchema(actual, schema("a1", "date"), schema("a2", "timestamp"));
+    verifyDataRows(actual, rows(null, null));
+  }
+
+  @Test
+  public void testAddtimeNull() {
+    JSONObject actual =
+        executeQuery(
+            String.format(
+                "source=%s | eval n1 = ADDTIME(date_time, date_time), n2 = ADDTIME(date, date), n3"
+                    + " = ADDTIME(time, time) | fields n1, n2, n3",
+                TEST_INDEX_DATE_FORMATS_WITH_NULL));
+    verifySchema(
+        actual, schema("n1", "timestamp"), schema("n2", "timestamp"), schema("n3", "time"));
+    verifyDataRows(actual, rows(null, null, null));
+  }
+
+  @Test
+  public void testConvertTzNull() {
+    JSONObject actual =
+        executeQuery(
+            String.format(
+                "source=%s | eval c1 = CONVERT_TZ(date, '+00:00', '+08:00'), c2 = CONVERT_TZ(date,"
+                    + " '-03:00', '+01:30') | fields c1, c2",
+                TEST_INDEX_DATE_FORMATS_WITH_NULL));
+    verifySchema(actual, schema("c1", "timestamp"), schema("c2", "timestamp"));
+    verifyDataRows(actual, rows(null, null));
+  }
+
+  @Test
+  public void testDateAddNull() {
+    JSONObject actual =
+        executeQuery(
+            String.format(
+                "source=%s | eval da1 = DATE_ADD(date, INTERVAL 1 DAY), da2 = DATE_ADD(date_time,"
+                    + " interval 5 month) | fields da1, da2",
+                TEST_INDEX_DATE_FORMATS_WITH_NULL));
+    verifySchema(actual, schema("da1", "timestamp"), schema("da2", "timestamp"));
+    verifyDataRows(actual, rows(null, null));
+  }
+
+  @Test
+  public void testDateFormatNull() {
+    JSONObject actual =
+        executeQuery(
+            String.format(
+                "source=%s | eval df1 = DATE_FORMAT(date, 'yyyy-MM-dd'), df2 ="
+                    + " DATE_FORMAT(date_time, 'yyyy-MM-dd HH:mm:ss') | fields df1, df2",
+                TEST_INDEX_DATE_FORMATS_WITH_NULL));
+    verifySchema(actual, schema("df1", "string"), schema("df2", "string"));
+    verifyDataRows(actual, rows(null, null));
+  }
+
+  @Test
+  public void testDateSubNull() {
+    JSONObject actual =
+        executeQuery(
+            String.format(
+                "source=%s | eval ds1 = DATE_SUB(date, INTERVAL 1 DAY), ds2 = DATE_SUB(date_time,"
+                    + " interval 5 month) | fields ds1, ds2",
+                TEST_INDEX_DATE_FORMATS_WITH_NULL));
+    verifySchema(actual, schema("ds1", "timestamp"), schema("ds2", "timestamp"));
+    verifyDataRows(actual, rows(null, null));
+  }
+
+  @Test
+  public void testDatediffNull() {
+    JSONObject actual =
+        executeQuery(
+            String.format(
+                "source=%s | eval diff1 = DATEDIFF(date, date), diff2 = DATEDIFF(date_time,"
+                    + " date_time) | fields diff1, diff2",
+                TEST_INDEX_DATE_FORMATS_WITH_NULL));
+    verifySchema(actual, schema("diff1", "long"), schema("diff2", "long"));
+    verifyDataRows(actual, rows(null, null));
+  }
+
+  @Test
+  public void testDatetimeNullString() {
+    JSONObject actual =
+        executeQuery(
+            String.format(
+                "source=%s | where age = 10 | eval d1 = DATETIME(name, '+10:00'), d2 ="
+                    + " datetime('2004-02-28 23:00:00-10:00', state)| fields d1, d2",
+                TEST_INDEX_STATE_COUNTRY_WITH_NULL));
+    verifySchema(actual, schema("d1", "timestamp"), schema("d2", "timestamp"));
+    verifyDataRows(actual, rows(null, null));
+  }
+
+  @Test
+  public void testDatetimeNullTimestamp() {
+    JSONObject actual =
+        executeQuery(
+            String.format(
+                "source=%s | eval d1 = DATETIME(date_time) | fields d1",
+                TEST_INDEX_DATE_FORMATS_WITH_NULL));
+    verifySchema(actual, schema("d1", "timestamp"));
+    verifyDataRows(actual, rows((Object) null));
+  }
+
+  @Test
+  public void testDayNull() {
+    JSONObject actual =
+        executeQuery(
+            String.format(
+                "source=%s | eval d1 = DAY(date), d2 = DAY(date_time) | fields d1, d2",
+                TEST_INDEX_DATE_FORMATS_WITH_NULL));
+    verifySchema(actual, schema("d1", "integer"), schema("d2", "integer"));
+    verifyDataRows(actual, rows(null, null));
+  }
+
+  @Test
+  public void testDaynameNull() {
+    JSONObject actual =
+        executeQuery(
+            String.format(
+                "source=%s | eval d1 = DAYNAME(date), d2 = DAYNAME(date_time) | fields d1, d2",
+                TEST_INDEX_DATE_FORMATS_WITH_NULL));
+    verifySchema(actual, schema("d1", "string"), schema("d2", "string"));
+    verifyDataRows(actual, rows(null, null));
+  }
+
+  @Test
+  public void testDayOfMonthNull() {
+    JSONObject actual =
+        executeQuery(
+            String.format(
+                "source=%s | eval d1 = DAY_OF_MONTH(date), d2 = DAYOFMONTH(date_time) | fields d1,"
+                    + " d2",
+                TEST_INDEX_DATE_FORMATS_WITH_NULL));
+    verifySchema(actual, schema("d1", "integer"), schema("d2", "integer"));
+    verifyDataRows(actual, rows(null, null));
+  }
+
+  @Ignore
+  @Test
+  public void testMicrosecondNull() {
+    JSONObject actual =
+        executeQuery(
+            String.format(
+                "source=%s | eval m1 = MICROSECOND(time), m2 = MICROSECOND(date_time) | fields m1,"
+                    + " m2",
+                TEST_INDEX_DATE_FORMATS_WITH_NULL));
+    verifySchema(actual, schema("m1", "integer"), schema("m2", "integer"));
+    verifyDataRows(actual, rows(null, null));
+  }
+
+  @Test
+  public void testMinuteNull() {
+    JSONObject actual =
+        executeQuery(
+            String.format(
+                "source=%s | eval m1 = MINUTE(time), m2 = MINUTE(date_time) | fields m1, m2",
+                TEST_INDEX_DATE_FORMATS_WITH_NULL));
+    verifySchema(actual, schema("m1", "integer"), schema("m2", "integer"));
+    verifyDataRows(actual, rows(null, null));
+  }
+
+  @Test
+  public void testMinuteOfDayNull() {
+    JSONObject actual =
+        executeQuery(
+            String.format(
+                "source=%s | eval md1 = MINUTE_OF_DAY(time), md2 = MINUTE_OF_DAY(date_time) |"
+                    + " fields md1, md2",
+                TEST_INDEX_DATE_FORMATS_WITH_NULL));
+    verifySchema(actual, schema("md1", "integer"), schema("md2", "integer"));
+    verifyDataRows(actual, rows(null, null));
+  }
+
+  @Test
+  public void testMinuteOfHourNull() {
+    JSONObject actual =
+        executeQuery(
+            String.format(
+                "source=%s | eval mh1 = MINUTE_OF_HOUR(time), mh2 = MINUTE_OF_HOUR(date_time) |"
+                    + " fields mh1, mh2",
+                TEST_INDEX_DATE_FORMATS_WITH_NULL));
+    verifySchema(actual, schema("mh1", "integer"), schema("mh2", "integer"));
+    verifyDataRows(actual, rows(null, null));
+  }
+
+  @Test
+  public void testMonthNull() {
+    JSONObject actual =
+        executeQuery(
+            String.format(
+                "source=%s | eval mo1 = MONTH(date), mo2 = MONTH(date_time) | fields mo1, mo2",
+                TEST_INDEX_DATE_FORMATS_WITH_NULL));
+    verifySchema(actual, schema("mo1", "integer"), schema("mo2", "integer"));
+    verifyDataRows(actual, rows(null, null));
+  }
+
+  @Test
+  public void testMonthOfYearNull() {
+    JSONObject actual =
+        executeQuery(
+            String.format(
+                "source=%s | eval mo1 = MONTH_OF_YEAR(date), mo2 = MONTH_OF_YEAR(date_time) |"
+                    + " fields mo1, mo2",
+                TEST_INDEX_DATE_FORMATS_WITH_NULL));
+    verifySchema(actual, schema("mo1", "integer"), schema("mo2", "integer"));
+    verifyDataRows(actual, rows(null, null));
+  }
+
+  @Test
+  public void testMonthnameNull() {
+    JSONObject actual =
+        executeQuery(
+            String.format(
+                "source=%s | eval mn1 = MONTHNAME(date), mn2 = MONTHNAME(date_time) | fields mn1,"
+                    + " mn2",
+                TEST_INDEX_DATE_FORMATS_WITH_NULL));
+    verifySchema(actual, schema("mn1", "string"), schema("mn2", "string"));
+    verifyDataRows(actual, rows(null, null));
+  }
+
+  @Test
+  public void testPeriodAddDiffNull() {
+    JSONObject actual =
+        executeQuery(
+            String.format(
+                "source=%s | where key='null' | head 1 | eval pa1 = PERIOD_ADD(`int`, 3), pa2 ="
+                    + " PERIOD_DIFF(`int`, `int`) | fields pa1, pa2",
+                TEST_INDEX_NULL_MISSING));
+
+    verifySchema(actual, schema("pa1", "integer"), schema("pa2", "integer"));
+    verifyDataRows(actual, rows(null, null));
+  }
+
+  @Test
+  public void testQuarterNull() {
+    JSONObject actual =
+        executeQuery(
+            String.format(
+                "source=%s | eval q1 = QUARTER(date), q2 = QUARTER(date_time) | fields q1, q2",
+                TEST_INDEX_DATE_FORMATS_WITH_NULL));
+    verifySchema(actual, schema("q1", "integer"), schema("q2", "integer"));
+    verifyDataRows(actual, rows(null, null));
+  }
+
+  @Test
+  public void testSecToTimeNull() {
+    JSONObject actual =
+        executeQuery(
+            String.format(
+                "source=%s | eval st1 = SEC_TO_TIME(UNIX_TIMESTAMP(date_time)), st2 ="
+                    + " SEC_TO_TIME(UNIX_TIMESTAMP(date)) | fields st1, st2",
+                TEST_INDEX_DATE_FORMATS_WITH_NULL));
+    verifySchema(actual, schema("st1", "time"), schema("st2", "time"));
+    verifyDataRows(actual, rows(null, null));
+  }
+
+  @Test
+  public void testSecondNull() {
+    JSONObject actual =
+        executeQuery(
+            String.format(
+                "source=%s | eval s1 = SECOND(time), s2 = SECOND(date_time) | fields s1, s2",
+                TEST_INDEX_DATE_FORMATS_WITH_NULL));
+    verifySchema(actual, schema("s1", "integer"), schema("s2", "integer"));
+    verifyDataRows(actual, rows(null, null));
+  }
+
+  @Test
+  public void testSecondOfMinuteNull() {
+    JSONObject actual =
+        executeQuery(
+            String.format(
+                "source=%s | eval s1 = SECOND_OF_MINUTE(time), s2 = SECOND_OF_MINUTE(date_time) |"
+                    + " fields s1, s2",
+                TEST_INDEX_DATE_FORMATS_WITH_NULL));
+    verifySchema(actual, schema("s1", "integer"), schema("s2", "integer"));
+    verifyDataRows(actual, rows(null, null));
+  }
+
+  @Test
+  public void testStrToDateNull() {
+    JSONObject actual =
+        executeQuery(
+            String.format(
+                "source=%s | eval s = STR_TO_DATE(MONTHNAME(date_time), '%%M') | fields s",
+                TEST_INDEX_DATE_FORMATS_WITH_NULL));
+    verifySchema(actual, schema("s", "timestamp"));
+    verifyDataRows(actual, rows((Object) null));
+  }
+
+  @Test
+  public void testSubdateNull() {
+    JSONObject actual =
+        executeQuery(
+            String.format(
+                "source=%s | eval sd1 = SUBDATE(date, 3), sd2 = SUBDATE(date_time, 5) | fields sd1,"
+                    + " sd2",
+                TEST_INDEX_DATE_FORMATS_WITH_NULL));
+    verifySchema(actual, schema("sd1", "date"), schema("sd2", "timestamp"));
+    verifyDataRows(actual, rows(null, null));
+  }
+
+  @Test
+  public void testSubtimeNull() {
+    JSONObject actual =
+        executeQuery(
+            String.format(
+                "source=%s | eval s1 = SUBTIME(date_time, date_time), s2 = SUBTIME(date, date), s3"
+                    + " = SUBTIME(time, time) | fields s1, s2, s3",
+                TEST_INDEX_DATE_FORMATS_WITH_NULL));
+    verifySchema(
+        actual, schema("s1", "timestamp"), schema("s2", "timestamp"), schema("s3", "time"));
+    verifyDataRows(actual, rows(null, null, null));
+  }
+
+  @Test
+  public void testTimeNull() {
+    JSONObject actual =
+        executeQuery(
+            String.format(
+                "source=%s | eval t1 = TIME(date_time) | fields t1",
+                TEST_INDEX_DATE_FORMATS_WITH_NULL));
+    verifySchema(actual, schema("t1", "time"));
+    verifyDataRows(actual, rows((Object) null));
+  }
+
+  @Test
+  public void testTimeFormatNull() {
+    JSONObject actual =
+        executeQuery(
+            String.format(
+                "source=%s | eval tf1 = TIME_FORMAT(time, '%%H:%%i:%%s') | fields tf1",
+                TEST_INDEX_DATE_FORMATS_WITH_NULL));
+    verifySchema(actual, schema("tf1", "string"));
+    verifyDataRows(actual, rows((Object) null));
+  }
+
+  @Test
+  public void testTimeToSecNull() {
+    JSONObject actual =
+        executeQuery(
+            String.format(
+                "source=%s | eval ts1 = TIME_TO_SEC(time) | fields ts1",
+                TEST_INDEX_DATE_FORMATS_WITH_NULL));
+    verifySchema(actual, schema("ts1", "long"));
+    verifyDataRows(actual, rows((Object) null));
+  }
+
+  @Test
+  public void testTimediffNull() {
+    JSONObject actual =
+        executeQuery(
+            String.format(
+                "source=%s | eval td1 = TIMEDIFF(time, time) | fields td1",
+                TEST_INDEX_DATE_FORMATS_WITH_NULL));
+    verifySchema(actual, schema("td1", "time"));
+    verifyDataRows(actual, rows((Object) null));
+  }
+
+  @Test
+  public void testTimestampNull() {
+    JSONObject actual =
+        executeQuery(
+            String.format(
+                "source=%s | eval t1 = TIMESTAMP(date, time), t2 = TIMESTAMP(date_time) | fields"
+                    + " t1, t2",
+                TEST_INDEX_DATE_FORMATS_WITH_NULL));
+    verifySchema(actual, schema("t1", "timestamp"), schema("t2", "timestamp"));
+    verifyDataRows(actual, rows(null, null));
+  }
+
+  @Test
+  public void testTimestampaddNull() {
+    JSONObject actual =
+        executeQuery(
+            String.format(
+                "source=%s | eval ta1 = TIMESTAMPADD(MONTH, 2, date), ta2 = TIMESTAMPADD(HOUR, 3,"
+                    + " date_time) | fields ta1, ta2",
+                TEST_INDEX_DATE_FORMATS_WITH_NULL));
+    verifySchema(actual, schema("ta1", "timestamp"), schema("ta2", "timestamp"));
+    verifyDataRows(actual, rows(null, null));
+  }
+
+  @Test
+  public void testTimestampdiffNull() {
+    JSONObject actual =
+        executeQuery(
+            String.format(
+                "source=%s | eval td1 = TIMESTAMPDIFF(DAY, date, date_time), td2 ="
+                    + " TIMESTAMPDIFF(HOUR, date_time, date_time) | fields td1, td2",
+                TEST_INDEX_DATE_FORMATS_WITH_NULL));
+    verifySchema(actual, schema("td1", "long"), schema("td2", "long"));
+    verifyDataRows(actual, rows(null, null));
+  }
+
+  @Test
+  public void testToDaysNull() {
+    JSONObject actual =
+        executeQuery(
+            String.format(
+                "source=%s | eval td1 = TO_DAYS(date), td2 = TO_DAYS(date_time) | fields td1, td2",
+                TEST_INDEX_DATE_FORMATS_WITH_NULL));
+    verifySchema(actual, schema("td1", "long"), schema("td2", "long"));
+    verifyDataRows(actual, rows(null, null));
+  }
+
+  @Test
+  public void testWeekNull() {
+    JSONObject actual =
+        executeQuery(
+            String.format(
+                "source=%s | eval w1 = WEEK(date), w2 = WEEK(date_time) | fields w1, w2",
+                TEST_INDEX_DATE_FORMATS_WITH_NULL));
+    verifySchema(actual, schema("w1", "integer"), schema("w2", "integer"));
+    verifyDataRows(actual, rows(null, null));
+  }
+
+  @Test
+  public void testWeekdayNull() {
+    JSONObject actual =
+        executeQuery(
+            String.format(
+                "source=%s | eval wd1 = WEEKDAY(date), wd2 = WEEKDAY(date_time) | fields wd1, wd2",
+                TEST_INDEX_DATE_FORMATS_WITH_NULL));
+    verifySchema(actual, schema("wd1", "integer"), schema("wd2", "integer"));
+    verifyDataRows(actual, rows(null, null));
+  }
+
+  @Test
+  public void testWeekOfYearNull() {
+    JSONObject actual =
+        executeQuery(
+            String.format(
+                "source=%s | eval wy1 = WEEK_OF_YEAR(date), wy2 = WEEK_OF_YEAR(date_time) | fields"
+                    + " wy1, wy2",
+                TEST_INDEX_DATE_FORMATS_WITH_NULL));
+    verifySchema(actual, schema("wy1", "integer"), schema("wy2", "integer"));
+    verifyDataRows(actual, rows(null, null));
+  }
+
+  @Test
+  public void testYearNull() {
+    JSONObject actual =
+        executeQuery(
+            String.format(
+                "source=%s | eval y1 = YEAR(date), y2 = YEAR(date_time) | fields y1, y2",
+                TEST_INDEX_DATE_FORMATS_WITH_NULL));
+    verifySchema(actual, schema("y1", "integer"), schema("y2", "integer"));
+    verifyDataRows(actual, rows(null, null));
+  }
 }

--- a/integ-test/src/test/java/org/opensearch/sql/calcite/standalone/CalcitePPLDateTimeBuiltinFunctionIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/calcite/standalone/CalcitePPLDateTimeBuiltinFunctionIT.java
@@ -1058,8 +1058,10 @@ public class CalcitePPLDateTimeBuiltinFunctionIT extends CalcitePPLIntegTestCase
                     + " '1999-12-31 00:00:00', TIMESTAMPADD(HOUR, -24, date_time)), d7 ="
                     + " TIMESTAMPDIFF(MONTH, TIMESTAMPADD(YEAR, 5, '1994-12-10 13:49:02'),"
                     + " ADDDATE(date_time, 1)), d8 = TIMESTAMPDIFF(QUARTER, MAKEDATE(2008, 153),"
-                    + " date), d9 = TIMESTAMPDIFF(YEAR, date, '2013-06-19 00:00:00')| fields d1,"
-                    + " d2, d3, d4, d5, d6, d7, d8, d9",
+                    + " date), d9 = TIMESTAMPDIFF(YEAR, date, '2013-06-19 00:00:00'), t ="
+                    + " TIMESTAMPADD(MICROSECOND, 1, date_time) | eval d10 ="
+                    + " TIMESTAMPDIFF(MICROSECOND, t, date_time) | fields d1, d2, d3, d4, d5, d6,"
+                    + " d7, d8, d9, t, d10",
                 TEST_INDEX_DATE_FORMATS));
 
     verifySchema(
@@ -1072,9 +1074,12 @@ public class CalcitePPLDateTimeBuiltinFunctionIT extends CalcitePPLIntegTestCase
         schema("d6", "long"),
         schema("d7", "long"),
         schema("d8", "long"),
-        schema("d9", "long"));
+        schema("d9", "long"),
+        schema("t", "timestamp"),
+        schema("d10", "long"));
 
-    verifyDataRows(actual, rows(0, 24, 547, 3600, 202, -820, -187, -96, 29));
+    verifyDataRows(
+        actual, rows(0, 24, 547, 3600, 202, -820, -187, -96, 29, "1984-04-12 09:07:42.000001", -1));
   }
 
   @Test

--- a/integ-test/src/test/java/org/opensearch/sql/legacy/SQLIntegTestCase.java
+++ b/integ-test/src/test/java/org/opensearch/sql/legacy/SQLIntegTestCase.java
@@ -763,10 +763,10 @@ public abstract class SQLIntegTestCase extends OpenSearchSQLRestTestCase {
         getMappingFile("date_formats_index_mapping.json"),
         "src/test/resources/date_formats.json"),
     DATE_FORMATS_WITH_NULL(
-            TestsConstants.TEST_INDEX_DATE_FORMATS_WITH_NULL,
-            "date_formats_null",
-            getMappingFile("date_formats_index_mapping.json"),
-            "src/test/resources/date_formats_with_null.json"),
+        TestsConstants.TEST_INDEX_DATE_FORMATS_WITH_NULL,
+        "date_formats_null",
+        getMappingFile("date_formats_index_mapping.json"),
+        "src/test/resources/date_formats_with_null.json"),
     WILDCARD(
         TestsConstants.TEST_INDEX_WILDCARD,
         "wildcard",

--- a/integ-test/src/test/java/org/opensearch/sql/legacy/TestsConstants.java
+++ b/integ-test/src/test/java/org/opensearch/sql/legacy/TestsConstants.java
@@ -54,7 +54,8 @@ public class TestsConstants {
   public static final String TEST_INDEX_NULL_MISSING = TEST_INDEX + "_null_missing";
   public static final String TEST_INDEX_CALCS = TEST_INDEX + "_calcs";
   public static final String TEST_INDEX_DATE_FORMATS = TEST_INDEX + "_date_formats";
-  public static final String TEST_INDEX_DATE_FORMATS_WITH_NULL = TEST_INDEX + "_date_formats_with_null";
+  public static final String TEST_INDEX_DATE_FORMATS_WITH_NULL =
+      TEST_INDEX + "_date_formats_with_null";
   public static final String TEST_INDEX_WILDCARD = TEST_INDEX + "_wildcard";
   public static final String TEST_INDEX_MULTI_NESTED_TYPE = TEST_INDEX + "_multi_nested";
   public static final String TEST_INDEX_NESTED_WITH_NULLS = TEST_INDEX + "_nested_with_nulls";


### PR DESCRIPTION
### Description
Add tests & apply patches for microsecond related ITs

### Covered ITs

**MICROSECOND as INTERVAL**
- [x]  ADDDATE | SUBDATE
- [x]  ADDTIME | SUBTIME
- [x]  TIMESTAMPADD | TIMESTAMPDIFF

**MICROSECOND in TIME / TIMESTAMP as arguments**
- [x]  TIME
- [x]  TIEMSTAMP
- [x]  CONVERT_TZ
- [x]  DATE  (with nanosecond datetime as arg)
- [x]  DATE_FORMAT
- [x]  EXTRACT
- [x]  MAKETIME
- [x]  MINUTE
- [x]  STR_TO_DATE

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).